### PR TITLE
make scipy optional

### DIFF
--- a/openpifpaf/plugins/apollocar3d/apollocar3d/metrics.py
+++ b/openpifpaf/plugins/apollocar3d/apollocar3d/metrics.py
@@ -1,10 +1,14 @@
 import logging
 
-import scipy.optimize as optimize
 import numpy as np
 
 from openpifpaf.metric.base import Base
 from openpifpaf.annotation import Annotation
+
+try:
+    import scipy
+except ImportError:
+    scipy = None
 
 LOG = logging.getLogger(__name__)
 
@@ -119,7 +123,7 @@ def hungarian_matching(gts, predictions, thresh=0.5):
             cost[i, j] = float(np.mean(distances))
 
     assert np.max(cost) < 11
-    row, cols = optimize.linear_sum_assignment(cost)
+    row, cols = scipy.optimize.linear_sum_assignment(cost)
     return row, cols, cost
 
 

--- a/openpifpaf/predict.py
+++ b/openpifpaf/predict.py
@@ -47,6 +47,9 @@ def cli():
                         help='rescale the long side of the image (aspect ratio maintained)')
     parser.add_argument('--loader-workers', default=None, type=int,
                         help='number of workers for data loading')
+    parser.add_argument('--precise-rescaling', dest='fast_rescaling',
+                        default=True, action='store_false',
+                        help='use more exact image rescaling (requires scipy)')
     parser.add_argument('--disable-cuda', action='store_true',
                         help='disable CUDA')
     args = parser.parse_args()
@@ -96,7 +99,7 @@ def processor_factory(args):
 def preprocess_factory(args):
     rescale_t = None
     if args.long_edge:
-        rescale_t = transforms.RescaleAbsolute(args.long_edge)
+        rescale_t = transforms.RescaleAbsolute(args.long_edge, fast=args.fast_rescaling)
 
     pad_t = None
     if args.batch_size > 1:

--- a/openpifpaf/transforms/image.py
+++ b/openpifpaf/transforms/image.py
@@ -3,10 +3,14 @@ import logging
 
 import numpy as np
 import PIL
-import scipy
 import torch
 
 from .preprocess import Preprocess
+
+try:
+    import scipy
+except ImportError:
+    scipy = None
 
 LOG = logging.getLogger(__name__)
 

--- a/openpifpaf/transforms/rotate.py
+++ b/openpifpaf/transforms/rotate.py
@@ -4,11 +4,15 @@ import math
 
 import numpy as np
 import PIL
-import scipy
 import torch
 
 from .preprocess import Preprocess
 from .. import utils
+
+try:
+    import scipy
+except ImportError:
+    scipy = None
 
 LOG = logging.getLogger(__name__)
 

--- a/openpifpaf/transforms/scale.py
+++ b/openpifpaf/transforms/scale.py
@@ -14,9 +14,9 @@ except ImportError:
     cv2 = None
 
 try:
-    import scipy
+    import scipy.ndimage
 except ImportError:
-    scipy = None
+    scipy = None  # pylint: disable=invalid-name
 
 LOG = logging.getLogger(__name__)
 

--- a/openpifpaf/transforms/scale.py
+++ b/openpifpaf/transforms/scale.py
@@ -14,7 +14,7 @@ except ImportError:
     cv2 = None
 
 try:
-    import scipy.ndimage
+    import scipy
 except ImportError:
     scipy = None
 

--- a/openpifpaf/transforms/scale.py
+++ b/openpifpaf/transforms/scale.py
@@ -4,7 +4,6 @@ import warnings
 
 import numpy as np
 import PIL
-import scipy.ndimage
 import torch
 
 from .preprocess import Preprocess
@@ -13,6 +12,11 @@ try:
     import cv2
 except ImportError:
     cv2 = None
+
+try:
+    import scipy.ndimage
+except ImportError:
+    scipy = None
 
 LOG = logging.getLogger(__name__)
 

--- a/openpifpaf/visualizer/occupancy.py
+++ b/openpifpaf/visualizer/occupancy.py
@@ -3,7 +3,7 @@ import logging
 from .base import Base
 
 try:
-    import scipy.ndimage
+    import scipy
 except ImportError:
     scipy = None
 

--- a/openpifpaf/visualizer/occupancy.py
+++ b/openpifpaf/visualizer/occupancy.py
@@ -1,8 +1,11 @@
 import logging
 
-import scipy
-
 from .base import Base
+
+try:
+    import scipy.ndimage
+except ImportError:
+    scipy = None
 
 LOG = logging.getLogger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ setup(
         'numpy>=1.16',
         'pysparkling',  # for log analysis
         'python-json-logger',
-        'scipy',
         'torch>=1.7.1',
         'torchvision>=0.8.2',
         'pillow',
@@ -96,6 +95,7 @@ setup(
         'train': [
             'matplotlib>=3.3',  # required by pycocotools
             'pycocotools>=2.0.1',  # pre-install cython (currently incompatible with numpy 1.18 or above)
+            'scipy',
         ],
     },
 )

--- a/tests/test_image_scale.py
+++ b/tests/test_image_scale.py
@@ -27,6 +27,7 @@ def test_pil_resize(resample):
 
 
 @pytest.mark.parametrize('order', [0, 1, 2, 3])
+@pytest.mark.slow
 def test_scipy_zoom(order):
     d_in = np.array([[0, 10, 20, 30, 40, 50]], dtype=np.uint8)
 

--- a/tests/test_image_scale.py
+++ b/tests/test_image_scale.py
@@ -25,8 +25,8 @@ def test_pil_resize(resample):
     assert np.all(d_in == d_out[0, ::2])
 
 
-@pytest.mark.parametrize('order', [0, 1, 2, 3])
 @pytest.mark.slow
+@pytest.mark.parametrize('order', [0, 1, 2, 3])
 def test_scipy_zoom(order):
     import scipy.ndimage  # pylint: disable=import-outside-toplevel
 

--- a/tests/test_image_scale.py
+++ b/tests/test_image_scale.py
@@ -28,7 +28,7 @@ def test_pil_resize(resample):
 @pytest.mark.parametrize('order', [0, 1, 2, 3])
 @pytest.mark.slow
 def test_scipy_zoom(order):
-    import scipy.ndimage
+    import scipy.ndimage  # pylint: disable=import-outside-toplevel
 
     d_in = np.array([[0, 10, 20, 30, 40, 50]], dtype=np.uint8)
 

--- a/tests/test_image_scale.py
+++ b/tests/test_image_scale.py
@@ -28,7 +28,7 @@ def test_pil_resize(resample):
 @pytest.mark.slow
 @pytest.mark.parametrize('order', [0, 1, 2, 3])
 def test_scipy_zoom(order):
-    import scipy.ndimage  # pylint: disable=import-outside-toplevel
+    import scipy.ndimage  # pylint: disable=import-outside-toplevel,import-error
 
     d_in = np.array([[0, 10, 20, 30, 40, 50]], dtype=np.uint8)
 

--- a/tests/test_image_scale.py
+++ b/tests/test_image_scale.py
@@ -3,7 +3,6 @@ import time
 import numpy as np
 import PIL.Image
 import pytest
-import scipy.ndimage
 
 try:
     import cv2
@@ -29,6 +28,8 @@ def test_pil_resize(resample):
 @pytest.mark.parametrize('order', [0, 1, 2, 3])
 @pytest.mark.slow
 def test_scipy_zoom(order):
+    import scipy.ndimage
+
     d_in = np.array([[0, 10, 20, 30, 40, 50]], dtype=np.uint8)
 
     w = d_in.shape[1]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -41,6 +41,7 @@ def single_pixel_transform(x, y, transform, image_wh=(13, 11)):
     )
 
 
+@pytest.mark.slow  # requires scipy
 def test_rescale_absolute(x=5, y=5):
     image_xy, keypoint_xy = single_pixel_transform(
         x, y, transforms.RescaleAbsolute(7), image_wh=(11, 11))


### PR DESCRIPTION
In most cases, scipy is only needed for training and the dependency is one of the blockers for arm64 (Apple M1).