### PR TITLE
Eval gt inversion

### DIFF
--- a/openpifpaf/annotation.py
+++ b/openpifpaf/annotation.py
@@ -186,19 +186,22 @@ class Annotation(Base):
             y_old = xy[:, 1].copy() - (rh - 1) / 2
             xy[:, 0] = (rw - 1) / 2 + cangle * x_old + sangle * y_old
             xy[:, 1] = (rh - 1) / 2 - sangle * x_old + cangle * y_old
-            ann.fixed_bbox = utils.rotate_box(ann.fixed_bbox, rw - 1, rh - 1, angle)
+            if ann.fixed_bbox is not None:
+                ann.fixed_bbox = utils.rotate_box(ann.fixed_bbox, rw - 1, rh - 1, angle)
 
         # offset
         ann.data[:, 0] += meta['offset'][0]
         ann.data[:, 1] += meta['offset'][1]
-        ann.fixed_bbox[:2] += meta['offset']
+        if ann.fixed_bbox is not None:
+            ann.fixed_bbox[:2] += meta['offset']
 
         # scale
         ann.data[:, 0] = ann.data[:, 0] / meta['scale'][0]
         ann.data[:, 1] = ann.data[:, 1] / meta['scale'][1]
         ann.joint_scales /= meta['scale'][0]
-        ann.fixed_bbox[:2] /= meta['scale']
-        ann.fixed_bbox[2:] /= meta['scale']
+        if ann.fixed_bbox is not None:
+            ann.fixed_bbox[:2] /= meta['scale']
+            ann.fixed_bbox[2:] /= meta['scale']
 
         assert not np.any(np.isnan(ann.data))
 
@@ -207,7 +210,8 @@ class Annotation(Base):
             ann.data[:, 0] = -ann.data[:, 0] + (w - 1)
             if meta.get('horizontal_swap'):
                 ann.data[:] = meta['horizontal_swap'](ann.data)
-            ann.fixed_bbox[0] = -(ann.fixed_bbox[0] + ann.fixed_bbox[2]) - 1.0 + w
+            if ann.fixed_bbox is not None:
+                ann.fixed_bbox[0] = -(ann.fixed_bbox[0] + ann.fixed_bbox[2]) - 1.0 + w
 
         for _, __, c1, c2 in ann.decoding_order:
             c1[:2] += meta['offset']

--- a/openpifpaf/annotation.py
+++ b/openpifpaf/annotation.py
@@ -170,8 +170,6 @@ class Annotation(Base):
         return [x, y, w, h]
 
     def inverse_transform(self, meta):
-        assert self.fixed_bbox is None
-
         ann = copy.deepcopy(self)
 
         # determine rotation parameters
@@ -188,15 +186,19 @@ class Annotation(Base):
             y_old = xy[:, 1].copy() - (rh - 1) / 2
             xy[:, 0] = (rw - 1) / 2 + cangle * x_old + sangle * y_old
             xy[:, 1] = (rh - 1) / 2 - sangle * x_old + cangle * y_old
+            ann.fixed_bbox = utils.rotate_box(ann.fixed_bbox, rw - 1, rh - 1, angle)
 
         # offset
         ann.data[:, 0] += meta['offset'][0]
         ann.data[:, 1] += meta['offset'][1]
+        ann.fixed_bbox[:2] += meta['offset']
 
         # scale
         ann.data[:, 0] = ann.data[:, 0] / meta['scale'][0]
         ann.data[:, 1] = ann.data[:, 1] / meta['scale'][1]
         ann.joint_scales /= meta['scale'][0]
+        ann.fixed_bbox[:2] /= meta['scale']
+        ann.fixed_bbox[2:] /= meta['scale']
 
         assert not np.any(np.isnan(ann.data))
 
@@ -205,6 +207,7 @@ class Annotation(Base):
             ann.data[:, 0] = -ann.data[:, 0] + (w - 1)
             if meta.get('horizontal_swap'):
                 ann.data[:] = meta['horizontal_swap'](ann.data)
+            ann.fixed_bbox[0] = -(ann.fixed_bbox[0] + ann.fixed_bbox[2]) - 1.0 + w
 
         for _, __, c1, c2 in ann.decoding_order:
             c1[:2] += meta['offset']

--- a/openpifpaf/eval.py
+++ b/openpifpaf/eval.py
@@ -160,13 +160,12 @@ def evaluate(args):
         assert len(image_tensors) == len(meta_batch)
         for pred, gt_anns, image_meta in zip(pred_batch, anns_batch, meta_batch):
             pred = [ann.inverse_transform(image_meta) for ann in pred]
+            gt_anns = [ann.inverse_transform(image_meta) for ann in gt_anns]
             for metric in metrics:
                 metric.accumulate(pred, image_meta, ground_truth=gt_anns)
 
             if args.show_final_image:
                 # show ground truth and predictions on original image
-                gt_anns = [ann.inverse_transform(image_meta) for ann in gt_anns]
-
                 annotation_painter = show.AnnotationPainter()
                 with open(image_meta['local_file_path'], 'rb') as f:
                     cpu_image = PIL.Image.open(f).convert('RGB')


### PR DESCRIPTION
Fix for #397.

This should solve the issue with visualization of ground truth annotations from custom datasets, and avoid assertion error in ApolloCar3D.

- Implement `inverse_transform` logic for the field `fixed_bbox` (copied from class `AnnotationDet`)
- Move the call to `inverse_transform` for gt before metrics' accumulation in eval.py

