### PR TITLE
mobilenetv2 checkpoint backwards compatibility

### DIFF
--- a/openpifpaf/network/factory.py
+++ b/openpifpaf/network/factory.py
@@ -11,6 +11,14 @@ from .. import headmeta
 from ..configurable import Configurable
 from . import basenetworks, heads, nets
 
+
+# monkey patch torchvision for mobilenetv2 checkpoint backwards compatibility
+if hasattr(torchvision.models, 'mobilenetv2') \
+   and not hasattr(torchvision.models.mobilenet, 'ConvBNReLU'):
+    torchvision.models.mobilenet.ConvBNReLU = torchvision.models.mobilenetv2.ConvBNReLU
+    torchvision.models.mobilenet.InvertedResidual = torchvision.models.mobilenetv2.InvertedResidual
+
+
 # generate hash values with: shasum -a 256 filename.pkl
 
 PRETRAINED_UNAVAILABLE = object()


### PR DESCRIPTION
With the introduction of mobilenetv3, some names changed for the mobilenetv2 checkpoint which are required to load an old checkpoint. This is a temporary patch for backwards compatibility. 

Closes #405 .