### PR TITLE
decoder priority

### DIFF
--- a/openpifpaf/decoder/cifcaf.py
+++ b/openpifpaf/decoder/cifcaf.py
@@ -96,6 +96,10 @@ class CifCaf(Decoder):
         if self.caf_visualizers is None:
             self.caf_visualizers = [visualizer.Caf(meta) for meta in caf_metas]
 
+        # prefer decoders with more keypoints and associations
+        self.priority += sum(m.n_fields for m in cif_metas) / 1000.0
+        self.priority += sum(m.n_fields for m in caf_metas) / 1000.0
+
         self.timers = defaultdict(float)
 
         # init by_target and by_source

--- a/openpifpaf/decoder/cifdet.py
+++ b/openpifpaf/decoder/cifdet.py
@@ -18,6 +18,10 @@ class CifDet(Decoder):
         super().__init__()
         self.metas = head_metas
 
+        # prefer decoders with more classes
+        self.priority = -1.0  # prefer keypoints over detections
+        self.priority += sum(m.n_fields for m in head_metas) / 1000.0
+
         self.visualizers = visualizers
         if self.visualizers is None:
             self.visualizers = [visualizer.CifDet(meta) for meta in self.metas]

--- a/openpifpaf/decoder/decoder.py
+++ b/openpifpaf/decoder/decoder.py
@@ -27,6 +27,7 @@ class Decoder:
     default_worker_pool = None
 
     def __init__(self):
+        self.priority = 0.0  # reference priority for single image CifCaf
         self.worker_pool = self.default_worker_pool
 
         if self.worker_pool is None or self.worker_pool == 0:

--- a/openpifpaf/decoder/factory.py
+++ b/openpifpaf/decoder/factory.py
@@ -136,12 +136,13 @@ class Factory:
         elif cls.decoder_request is None:
             LOG.info(
                 'No specific decoder requested. Using the first one from:\n'
-                + '\n'.join(
+                '%s\n'
+                'Use any of the above arguments to select one or multiple '
+                'decoders and to suppress this message.',
+                '\n'.join(
                     f'  --decoder={dec.__class__.__name__.lower()}:{dec.request_index}'
                     for dec in decoders
                 )
-                + '\nUse any of the above arguments to select one or multiple '
-                'decoders and to suppress this message.'
             )
             decoders = [decoders[0]]
 

--- a/openpifpaf/decoder/factory.py
+++ b/openpifpaf/decoder/factory.py
@@ -58,7 +58,7 @@ def configure(args):
             args.instance_threshold = utils.nms.Keypoints.instance_threshold
 
     # configure Factory
-    Factory.decoder_filter_from_args(args.decoder)
+    Factory.decoder_request_from_args(args.decoder)
     Factory.profile = args.profile_decoder
     Factory.profile_device = args.device
 
@@ -86,57 +86,64 @@ def configure(args):
 
 
 class Factory:
-    decoder_filter: Optional[dict] = None
+    decoder_request: Optional[dict] = None
     profile = False
     profile_device = None
 
     @classmethod
-    def decoder_filter_from_args(cls, list_str):
+    def decoder_request_from_args(cls, list_str):
         if list_str is None:
-            cls.decoder_filter = None
+            cls.decoder_request = None
             return
 
-        cls.decoder_filter = defaultdict(list)
+        cls.decoder_request = defaultdict(list)
         for dec_str in list_str:
             # pylint: disable=unsupported-assignment-operation,unsupported-membership-test,unsubscriptable-object
             if ':' not in dec_str:
-                if dec_str not in cls.decoder_filter:
-                    cls.decoder_filter[dec_str] = []
+                if dec_str not in cls.decoder_request:
+                    cls.decoder_request[dec_str] = []
                 continue
 
             dec_str, _, index = dec_str.partition(':')
             index = int(index)
-            cls.decoder_filter[dec_str].append(index)
+            cls.decoder_request[dec_str].append(index)
 
-        LOG.debug('setup decoder filter: %s', cls.decoder_filter)
+        LOG.debug('setup decoder request: %s', cls.decoder_request)
 
     @classmethod
     def decoders(cls, head_metas):
-        if cls.decoder_filter is not None:
-            # pylint: disable=unsupported-membership-test,unsubscriptable-object
-            decoders_by_class = {dec_class.__name__.lower(): dec_class
-                                 for dec_class in DECODERS}
-            decoders_by_class = {c: ds.factory(head_metas)
-                                 for c, ds in decoders_by_class.items()
-                                 if c in cls.decoder_filter}
-            LOG.debug('all decoders by class: %s', decoders_by_class)
-            decoders_by_class = {c: [d
-                                     for i, d in enumerate(ds)
-                                     if (not cls.decoder_filter[c]
-                                         or i in cls.decoder_filter[c])]
-                                 for c, ds in decoders_by_class.items()}
-            decoders = [d for ds in decoders_by_class.values() for d in ds]
-            LOG.debug('filtered decoders (%d) by class: %s', len(decoders), decoders_by_class)
-        else:
-            decoders = [
-                d
-                for dec_class in DECODERS
-                for d in dec_class.factory(head_metas)
-            ]
-            LOG.debug('created %d decoders', len(decoders))
+        def per_class(request, dec_class):
+            class_name = dec_class.__name__.lower()
+            if request is not None \
+               and class_name not in request:
+                return []
+            decoders = sorted(dec_class.factory(head_metas), key=lambda d: d.priority, reverse=True)
+            for dec_i, dec in enumerate(decoders):
+                dec.request_index = dec_i
+            if request is not None:
+                indices = set(request[class_name])
+                decoders = (d for i, d in enumerate(decoders) if i in indices)
+            return decoders
+
+        decoders = [d for dec_class in DECODERS for d in per_class(cls.decoder_request, dec_class)]
+        decoders = list(sorted(decoders, key=lambda d: d.priority, reverse=True))
+        LOG.debug('created %d decoders', len(decoders))
 
         if not decoders:
             LOG.warning('no decoders found for heads %s', [meta.name for meta in head_metas])
+        elif len(decoders) == 1:
+            pass
+        elif cls.decoder_request is None:
+            LOG.info(
+                'No specific decoder requested. Using the first one from:\n'
+                + '\n'.join(
+                    f'  --decoder={dec.__class__.__name__.lower()}:{dec.request_index}'
+                    for dec in decoders
+                )
+                + '\nUse any of the above arguments to select one or multiple '
+                'decoders and to suppress this message.'
+            )
+            decoders = [decoders[0]]
 
         return decoders
 


### PR DESCRIPTION
Behavior change when `--decoder=` is __not__ provided on the command line.

_Before_: all possible decoders for the given head networks in the model are run.
_After_: decoders have an internal priority and only the decoder with the highest priority is run by default.

The internal priority is now also used to sort the created decoders. Roughly, priority is higher for more fine-grained decoders (keypoints over detections) and higher for decoders that operate on more fields (decoder for 100 keypoints over decoder for 17 keypoints).

Multiple decoders can still be explicitly selected with multiple arguments to `--decoder=`.