### PR TITLE
avoid centerpad when batch=1

### DIFF
--- a/openpifpaf/eval.py
+++ b/openpifpaf/eval.py
@@ -60,7 +60,7 @@ def cli():
     decoder.cli(parser)
     logger.cli(parser)
     network.Factory.cli(parser)
-    Predictor.cli(parser)
+    Predictor.cli(parser, skip_batch_size=True, skip_loader_workers=True)
     show.cli(parser)
     visualizer.cli(parser)
 

--- a/openpifpaf/predict.py
+++ b/openpifpaf/predict.py
@@ -41,10 +41,6 @@ def cli():
     parser.add_argument('--json-output', default=None, nargs='?', const=True,
                         help='Whether to output a json file, '
                              'with the option to specify the output path or directory')
-    parser.add_argument('--batch-size', default=1, type=int,
-                        help='processing batch size')
-    parser.add_argument('--loader-workers', default=None, type=int,
-                        help='number of workers for data loading')
     parser.add_argument('--disable-cuda', action='store_true',
                         help='disable CUDA')
     args = parser.parse_args()
@@ -108,8 +104,7 @@ def main():
         visualize_image=(args.show or args.image_output is not None),
         visualize_processed_image=args.debug,
     )
-    for pred, _, meta in predictor.images(
-            args.images, batch_size=args.batch_size, loader_workers=args.loader_workers):
+    for pred, _, meta in predictor.images(args.images):
         # json output
         if args.json_output is not None:
             json_out_name = out_name(

--- a/openpifpaf/predictor.py
+++ b/openpifpaf/predictor.py
@@ -47,12 +47,24 @@ class Predictor:
                  self.device, torch.cuda.is_available(), torch.cuda.device_count())
 
     @classmethod
-    def cli(cls, parser: argparse.ArgumentParser):
+    def cli(cls, parser: argparse.ArgumentParser, *,
+            skip_batch_size=False, skip_loader_workers=False):
+        """Add arguments.
+
+        When using this class together with datasets (e.g. in eval),
+        skip the cli arguments for batch size and loader workers as those
+        will be provided via the datasets module.
+        """
         group = parser.add_argument_group('Predictor')
-        group.add_argument('--batch-size', default=cls.batch_size, type=int,
-                           help='processing batch size')
-        group.add_argument('--loader-workers', default=cls.loader_workers, type=int,
-                           help='number of workers for data loading')
+
+        if not skip_batch_size:
+            group.add_argument('--batch-size', default=cls.batch_size, type=int,
+                               help='processing batch size')
+
+        if not skip_loader_workers:
+            group.add_argument('--loader-workers', default=cls.loader_workers, type=int,
+                               help='number of workers for data loading')
+
         group.add_argument('--long-edge', default=cls.long_edge, type=int,
                            help='rescale the long side of the image (aspect ratio maintained)')
         group.add_argument('--precise-rescaling', dest='fast_rescaling',

--- a/openpifpaf/predictor.py
+++ b/openpifpaf/predictor.py
@@ -87,7 +87,8 @@ class Predictor:
         ])
 
     def dataset(self, data):
-        if self.loader_workers is None:
+        loader_workers = self.loader_workers
+        if loader_workers is None:
             loader_workers = self.batch_size if len(data) > 1 else 0
 
         dataloader = torch.utils.data.DataLoader(

--- a/openpifpaf/video.py
+++ b/openpifpaf/video.py
@@ -109,6 +109,7 @@ def cli():  # pylint: disable=too-many-statements,too-many-branches
 def main():
     args = cli()
 
+    Predictor.loader_workers = 1
     predictor = Predictor(
         visualize_image=(not args.json_output or args.video_output),
         visualize_processed_image=args.debug,
@@ -123,7 +124,7 @@ def main():
 
     last_loop = time.perf_counter()
     for (ax, ax_second), (preds, _, meta) in \
-            zip(animation.iter(), predictor.dataset(capture, loader_workers=1)):
+            zip(animation.iter(), predictor.dataset(capture)):
         image = visualizer.Base._image  # pylint: disable=protected-access
         if ax is None and (not args.json_output or args.video_output):
             ax, ax_second = animation.frame_init(image)


### PR DESCRIPTION
This restores previous behavior:
https://github.com/openpifpaf/openpifpaf/blob/94de51ebb0cc5d7d7397f7880191f9f1c8f414e9/openpifpaf/predict.py#L105

When introducing the `Predictor` class, the logic to pick the right padding strategy changed. This PR reverts that change. It also changes the Predictor API slightly and makes it handle `--batch-size` and `--loader-workers` arguments.