### PR TITLE
New transformer backbones: Swin and XCiT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,6 +3,10 @@ Copyright 2019-2021 by Sven Kreiss and contributors. All rights reserved.
 This project and all its files are licensed under
 GNU AGPLv3 or later version.
 
+The following files have other licenses:
+- openpifpaf/network/swin_transformer.py: docs/LICENSE.SWIN
+- openpifpaf/network/xcit.py: docs/LICENSE.XCIT
+
 If this license is not suitable for your business or project
 please contact EPFL-TTO (https://tto.epfl.ch/) for a full commercial license.
 

--- a/docs/LICENSE.SWIN
+++ b/docs/LICENSE.SWIN
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/docs/LICENSE.XCIT
+++ b/docs/LICENSE.XCIT
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 - present, Facebook, Inc
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -559,7 +559,7 @@ class XCiT(BaseNetwork):
     def __init__(self, name, xcit_net, out_features=2048):
         embed_dim = xcit_net().embed_dim
         has_projection = isinstance(self.out_features, int)
-        self.out_features = self.out_features if has_projection else embed_dim
+        self.out_features = self.out_features if has_projection else (8 * embed_dim)
 
         super().__init__(name, stride=self.stride, out_features=out_features)
 

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -536,7 +536,7 @@ class SwinTransformer(BaseNetwork):
     @classmethod
     def cli(cls, parser: argparse.ArgumentParser):
         group = parser.add_argument_group('SwinTransformer')
-        group.add_argument('--swin_out-features',
+        group.add_argument('--swin-out-features',
                            default=cls.out_features, type=int,
                            help='number of output features for optional projection layer '
                                 '(None for no projection layer)')

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -558,10 +558,8 @@ class XCiT(BaseNetwork):
 
     def __init__(self, name, xcit_net, out_features=2048):
         embed_dim = xcit_net().embed_dim
-        has_projection = not isinstance(self.out_features, int)
+        has_projection = isinstance(self.out_features, int)
         self.out_features = self.out_features if has_projection else embed_dim
-
-
 
         super().__init__(name, stride=self.stride, out_features=out_features)
 

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -504,7 +504,7 @@ class SwinTransformer(BaseNetwork):
 
     def __init__(self, name, swin_net):
         embed_dim = swin_net().embed_dim
-        has_projection = not isinstance(self.out_features, int)
+        has_projection = isinstance(self.out_features, int)
         self.out_features = self.out_features if has_projection else embed_dim
 
         super().__init__(name, stride=16, out_features=self.out_features)

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -556,12 +556,12 @@ class XCiT(BaseNetwork):
     out_features = None
     stride = 16
 
-    def __init__(self, name, xcit_net, out_features=2048):
+    def __init__(self, name, xcit_net):
         embed_dim = xcit_net().embed_dim
         has_projection = isinstance(self.out_features, int)
         self.out_features = self.out_features if has_projection else embed_dim
 
-        super().__init__(name, stride=self.stride, out_features=out_features)
+        super().__init__(name, stride=self.stride, out_features=self.out_features)
 
         self.backbone = xcit_net(pretrained=self.pretrained)
 

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -563,6 +563,7 @@ class SwinTransformer(BaseNetwork):
     @classmethod
     def configure(cls, args: argparse.Namespace):
         cls.out_features = args.swin_out_features
+        cls.stride = args.swin_stride
         cls.pretrained = args.swin_pretrained
 
 

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -496,3 +496,41 @@ class SqueezeNet(BaseNetwork):
     @classmethod
     def configure(cls, args: argparse.Namespace):
         cls.pretrained = args.squeezenet_pretrained
+
+
+class SwinTransformer(BaseNetwork):
+
+    def __init__(self, name, swin_net, out_features=2048):
+        super().__init__(name, stride=16, out_features=out_features)
+        self.backbone = swin_net(pretrained=True, out_dim=out_features)
+
+    def forward(self, x):
+        x = self.backbone(x)
+        return x
+
+    @classmethod
+    def cli(cls, parser: argparse.ArgumentParser):
+        pass
+
+    @classmethod
+    def configure(cls, args: argparse.Namespace):
+        pass
+
+
+class XCiT(BaseNetwork):
+
+    def __init__(self, name, xcit_net, out_features=2048):
+        super().__init__(name, stride=16, out_features=out_features)
+        self.backbone = xcit_net(pretrained=True, out_dim=out_features)
+
+    def forward(self, x):
+        x = self.backbone(x)
+        return x
+
+    @classmethod
+    def cli(cls, parser: argparse.ArgumentParser):
+        pass
+
+    @classmethod
+    def configure(cls, args: argparse.Namespace):
+        pass

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -600,7 +600,8 @@ class XCiT(BaseNetwork):
 
         group.add_argument('--xcit-stride',
                            default=cls.stride, type=int,
-                           help='stride (must be 16 for patch size 16, and 8 or 16 for patch size 8)')
+                           help='stride (must be 16 for patch size 16, '
+                                'and 8 or 16 for patch size 8)')
 
         group.add_argument('--xcit-no-pretrain', dest='xcit_pretrained',
                            default=True, action='store_false',

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -505,7 +505,7 @@ class SwinTransformer(BaseNetwork):
     def __init__(self, name, swin_net):
         embed_dim = swin_net().embed_dim
         has_projection = isinstance(self.out_features, int)
-        self.out_features = self.out_features if has_projection else embed_dim
+        self.out_features = self.out_features if has_projection else 8 * embed_dim
 
         super().__init__(name, stride=16, out_features=self.out_features)
 
@@ -559,7 +559,7 @@ class XCiT(BaseNetwork):
     def __init__(self, name, xcit_net, out_features=2048):
         embed_dim = xcit_net().embed_dim
         has_projection = isinstance(self.out_features, int)
-        self.out_features = self.out_features if has_projection else (8 * embed_dim)
+        self.out_features = self.out_features if has_projection else embed_dim
 
         super().__init__(name, stride=self.stride, out_features=out_features)
 
@@ -568,7 +568,7 @@ class XCiT(BaseNetwork):
         if has_projection:
             LOG.debug('adding output projection to %d features', self.out_features)
             self.out_projection = torch.nn.Conv2d(
-                8 * embed_dim, self.out_features, kernel_size=1, stride=1)
+                embed_dim, self.out_features, kernel_size=1, stride=1)
         else:
             LOG.debug('no output projection')
             self.out_projection = torch.nn.Identity()

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -537,8 +537,8 @@ class SwinTransformer(BaseNetwork):
         group = parser.add_argument_group('SwinTransformer')
         group.add_argument('--swin_out-features',
                            default=cls.out_features, type=int,
-                           help='number of output features for optional projection layer,'
-                                '(no projection layer by default)')
+                           help='number of output features for optional projection layer '
+                                '(None for no projection layer)')
 
         group.add_argument('--swin-no-pretrain', dest='swin_pretrained',
                            default=True, action='store_false',
@@ -591,13 +591,12 @@ class XCiT(BaseNetwork):
         group = parser.add_argument_group('XCiT')
         group.add_argument('--xcit-out-features',
                            default=cls.out_features, type=int,
-                           help='number of output features for optional projection layer,'
-                                '(no projection layer by default)')
+                           help='number of output features for optional projection layer '
+                                '(None for no projection layer)')
 
         group.add_argument('--xcit-stride',
                            default=cls.stride, type=int,
-                           help='stride (must be 16 for patch size 16, and 8 or 16 for patch size 8,'
-                                '(default: %(default)s)')
+                           help='stride (must be 16 for patch size 16, and 8 or 16 for patch size 8)')
 
         group.add_argument('--xcit-no-pretrain', dest='xcit_pretrained',
                            default=True, action='store_false',

--- a/openpifpaf/network/factory.py
+++ b/openpifpaf/network/factory.py
@@ -66,11 +66,11 @@ BASE_FACTORIES = {
     'shufflenetv2k44': lambda: basenetworks.ShuffleNetV2K(
         'shufflenetv2k44', [12, 24, 8], [32, 512, 1024, 2048, 2048]),
     'squeezenet': lambda: basenetworks.SqueezeNet('squeezenet', torchvision.models.squeezenet1_1),
-    # Swin architectures: swin_t is roughly equivalent to resnet50
+    # Swin architectures: swin_t is roughly equivalent to to original resnet50 (not the modified one from openpifpaf)
     'swin_t': lambda: basenetworks.SwinTransformer('swin_t', swin_net=swin_transformer.swin_tiny_patch4_window7),
     'swin_s': lambda: basenetworks.SwinTransformer('swin_s', swin_net=swin_transformer.swin_small_patch4_window7),
     'swin_b': lambda: basenetworks.SwinTransformer('swin_b', swin_net=swin_transformer.swin_base_patch4_window7),
-    # XCiT architectures: xcit_small_12_p16 is roughly equivalent to resnet50
+    # XCiT architectures: xcit_small_12_p16 is roughly equivalent to original resnet50 (not the modified one from openpifpaf)
     'xcit_nano_12_p16': lambda: basenetworks.XCiT('xcit_nano_12_p16', xcit_net=xcit.xcit_nano_12_p16),
     'xcit_tiny_12_p16': lambda: basenetworks.XCiT('xcit_tiny_12_p16', xcit_net=xcit.xcit_tiny_12_p16),
     'xcit_tiny_24_p16': lambda: basenetworks.XCiT('xcit_tiny_24_p16', xcit_net=xcit.xcit_tiny_24_p16),
@@ -78,6 +78,14 @@ BASE_FACTORIES = {
     'xcit_small_24_p16': lambda: basenetworks.XCiT('xcit_small_24_p16', xcit_net=xcit.xcit_small_24_p16),
     'xcit_medium_24_p16': lambda: basenetworks.XCiT('xcit_medium_24_p16', xcit_net=xcit.xcit_medium_24_p16),
     'xcit_large_24_p16': lambda: basenetworks.XCiT('xcit_large_24_p16', xcit_net=xcit.xcit_large_24_p16),
+    'xcit_nano_12_p8': lambda : basenetworks.XCiT('xcit_nano_12_p8', xcit_net=xcit.xcit_nano_12_p8),
+    'xcit_tiny_12_p8': lambda: basenetworks.XCiT('xcit_tiny_12_p8', xcit_net=xcit.xcit_tiny_12_p8),
+    'xcit_tiny_24_p8': lambda: basenetworks.XCiT('xcit_tiny_24_p8', xcit_net=xcit.xcit_tiny_24_p8),
+    'xcit_small_12_p8': lambda: basenetworks.XCiT('xcit_small_12_p8', xcit_net=xcit.xcit_small_12_p8),
+    'xcit_small_24_p8': lambda: basenetworks.XCiT('xcit_small_24_p8', xcit_net=xcit.xcit_small_24_p8),
+    'xcit_medium_24_p8': lambda: basenetworks.XCiT('xcit_medium_24_p8', xcit_net=xcit.xcit_medium_24_p8),
+    'xcit_large_24_p8': lambda: basenetworks.XCiT('xcit_large_24_p8', xcit_net=xcit.xcit_large_24_p8),
+
 }
 
 #: headmeta class to head class

--- a/openpifpaf/network/factory.py
+++ b/openpifpaf/network/factory.py
@@ -10,6 +10,7 @@ import torchvision
 from .. import headmeta
 from ..configurable import Configurable
 from . import basenetworks, heads, nets
+from . import  swin_transformer, xcit
 
 
 # monkey patch torchvision for mobilenetv2 checkpoint backwards compatibility
@@ -34,6 +35,8 @@ BASE_TYPES = set([
     basenetworks.ShuffleNetV2,
     basenetworks.ShuffleNetV2K,
     basenetworks.SqueezeNet,
+    basenetworks.SwinTransformer,
+    basenetworks.XCiT,
 ])
 BASE_FACTORIES = {
     'mobilenetv2': lambda: basenetworks.MobileNetV2('mobilenetv2', torchvision.models.mobilenet_v2),
@@ -63,6 +66,18 @@ BASE_FACTORIES = {
     'shufflenetv2k44': lambda: basenetworks.ShuffleNetV2K(
         'shufflenetv2k44', [12, 24, 8], [32, 512, 1024, 2048, 2048]),
     'squeezenet': lambda: basenetworks.SqueezeNet('squeezenet', torchvision.models.squeezenet1_1),
+    # Swin architectures: swin_t is roughly equivalent to resnet50
+    'swin_t': lambda: basenetworks.SwinTransformer('swin_t', swin_net=swin_transformer.swin_tiny_patch4_window7),
+    'swin_s': lambda: basenetworks.SwinTransformer('swin_s', swin_net=swin_transformer.swin_small_patch4_window7),
+    'swin_b': lambda: basenetworks.SwinTransformer('swin_b', swin_net=swin_transformer.swin_base_patch4_window7),
+    # XCiT architectures: xcit_small_12_p16 is roughly equivalent to resnet50
+    'xcit_nano_12_p16': lambda: basenetworks.XCiT('xcit_nano_12_p16', xcit_net=xcit.xcit_nano_12_p16),
+    'xcit_tiny_12_p16': lambda: basenetworks.XCiT('xcit_tiny_12_p16', xcit_net=xcit.xcit_tiny_12_p16),
+    'xcit_tiny_24_p16': lambda: basenetworks.XCiT('xcit_tiny_24_p16', xcit_net=xcit.xcit_tiny_24_p16),
+    'xcit_small_12_p16': lambda: basenetworks.XCiT('xcit_small_12_p16', xcit_net=xcit.xcit_small_12_p16),
+    'xcit_small_24_p16': lambda: basenetworks.XCiT('xcit_small_24_p16', xcit_net=xcit.xcit_small_24_p16),
+    'xcit_medium_24_p16': lambda: basenetworks.XCiT('xcit_medium_24_p16', xcit_net=xcit.xcit_medium_24_p16),
+    'xcit_large_24_p16': lambda: basenetworks.XCiT('xcit_large_24_p16', xcit_net=xcit.xcit_large_24_p16),
 }
 
 #: headmeta class to head class

--- a/openpifpaf/network/factory.py
+++ b/openpifpaf/network/factory.py
@@ -10,7 +10,7 @@ import torchvision
 from .. import headmeta
 from ..configurable import Configurable
 from . import basenetworks, heads, nets
-from . import  swin_transformer, xcit
+from . import swin_transformer, xcit
 
 
 # monkey patch torchvision for mobilenetv2 checkpoint backwards compatibility
@@ -66,11 +66,11 @@ BASE_FACTORIES = {
     'shufflenetv2k44': lambda: basenetworks.ShuffleNetV2K(
         'shufflenetv2k44', [12, 24, 8], [32, 512, 1024, 2048, 2048]),
     'squeezenet': lambda: basenetworks.SqueezeNet('squeezenet', torchvision.models.squeezenet1_1),
-    # Swin architectures: swin_t is roughly equivalent to to original resnet50 (not the modified one from openpifpaf)
+    # Swin architectures: swin_t is roughly equivalent to to original, unmodified, resnet50
     'swin_t': lambda: basenetworks.SwinTransformer('swin_t', swin_net=swin_transformer.swin_tiny_patch4_window7),
     'swin_s': lambda: basenetworks.SwinTransformer('swin_s', swin_net=swin_transformer.swin_small_patch4_window7),
     'swin_b': lambda: basenetworks.SwinTransformer('swin_b', swin_net=swin_transformer.swin_base_patch4_window7),
-    # XCiT architectures: xcit_small_12_p16 is roughly equivalent to original resnet50 (not the modified one from openpifpaf)
+    # XCiT architectures: xcit_small_12_p16 is roughly equivalent to original, unmodified, resnet50
     'xcit_nano_12_p16': lambda: basenetworks.XCiT('xcit_nano_12_p16', xcit_net=xcit.xcit_nano_12_p16),
     'xcit_tiny_12_p16': lambda: basenetworks.XCiT('xcit_tiny_12_p16', xcit_net=xcit.xcit_tiny_12_p16),
     'xcit_tiny_24_p16': lambda: basenetworks.XCiT('xcit_tiny_24_p16', xcit_net=xcit.xcit_tiny_24_p16),
@@ -78,7 +78,7 @@ BASE_FACTORIES = {
     'xcit_small_24_p16': lambda: basenetworks.XCiT('xcit_small_24_p16', xcit_net=xcit.xcit_small_24_p16),
     'xcit_medium_24_p16': lambda: basenetworks.XCiT('xcit_medium_24_p16', xcit_net=xcit.xcit_medium_24_p16),
     'xcit_large_24_p16': lambda: basenetworks.XCiT('xcit_large_24_p16', xcit_net=xcit.xcit_large_24_p16),
-    'xcit_nano_12_p8': lambda : basenetworks.XCiT('xcit_nano_12_p8', xcit_net=xcit.xcit_nano_12_p8),
+    'xcit_nano_12_p8': lambda: basenetworks.XCiT('xcit_nano_12_p8', xcit_net=xcit.xcit_nano_12_p8),
     'xcit_tiny_12_p8': lambda: basenetworks.XCiT('xcit_tiny_12_p8', xcit_net=xcit.xcit_tiny_12_p8),
     'xcit_tiny_24_p8': lambda: basenetworks.XCiT('xcit_tiny_24_p8', xcit_net=xcit.xcit_tiny_24_p8),
     'xcit_small_12_p8': lambda: basenetworks.XCiT('xcit_small_12_p8', xcit_net=xcit.xcit_small_12_p8),

--- a/openpifpaf/network/factory.py
+++ b/openpifpaf/network/factory.py
@@ -66,26 +66,28 @@ BASE_FACTORIES = {
     'shufflenetv2k44': lambda: basenetworks.ShuffleNetV2K(
         'shufflenetv2k44', [12, 24, 8], [32, 512, 1024, 2048, 2048]),
     'squeezenet': lambda: basenetworks.SqueezeNet('squeezenet', torchvision.models.squeezenet1_1),
-    # Swin architectures: swin_t is roughly equivalent to to original, unmodified, resnet50
-    'swin_t': lambda: basenetworks.SwinTransformer('swin_t', swin_net=swin_transformer.swin_tiny_patch4_window7),
-    'swin_s': lambda: basenetworks.SwinTransformer('swin_s', swin_net=swin_transformer.swin_small_patch4_window7),
-    'swin_b': lambda: basenetworks.SwinTransformer('swin_b', swin_net=swin_transformer.swin_base_patch4_window7),
-    # XCiT architectures: xcit_small_12_p16 is roughly equivalent to original, unmodified, resnet50
-    'xcit_nano_12_p16': lambda: basenetworks.XCiT('xcit_nano_12_p16', xcit_net=xcit.xcit_nano_12_p16),
-    'xcit_tiny_12_p16': lambda: basenetworks.XCiT('xcit_tiny_12_p16', xcit_net=xcit.xcit_tiny_12_p16),
-    'xcit_tiny_24_p16': lambda: basenetworks.XCiT('xcit_tiny_24_p16', xcit_net=xcit.xcit_tiny_24_p16),
-    'xcit_small_12_p16': lambda: basenetworks.XCiT('xcit_small_12_p16', xcit_net=xcit.xcit_small_12_p16),
-    'xcit_small_24_p16': lambda: basenetworks.XCiT('xcit_small_24_p16', xcit_net=xcit.xcit_small_24_p16),
-    'xcit_medium_24_p16': lambda: basenetworks.XCiT('xcit_medium_24_p16', xcit_net=xcit.xcit_medium_24_p16),
-    'xcit_large_24_p16': lambda: basenetworks.XCiT('xcit_large_24_p16', xcit_net=xcit.xcit_large_24_p16),
-    'xcit_nano_12_p8': lambda: basenetworks.XCiT('xcit_nano_12_p8', xcit_net=xcit.xcit_nano_12_p8),
-    'xcit_tiny_12_p8': lambda: basenetworks.XCiT('xcit_tiny_12_p8', xcit_net=xcit.xcit_tiny_12_p8),
-    'xcit_tiny_24_p8': lambda: basenetworks.XCiT('xcit_tiny_24_p8', xcit_net=xcit.xcit_tiny_24_p8),
-    'xcit_small_12_p8': lambda: basenetworks.XCiT('xcit_small_12_p8', xcit_net=xcit.xcit_small_12_p8),
-    'xcit_small_24_p8': lambda: basenetworks.XCiT('xcit_small_24_p8', xcit_net=xcit.xcit_small_24_p8),
-    'xcit_medium_24_p8': lambda: basenetworks.XCiT('xcit_medium_24_p8', xcit_net=xcit.xcit_medium_24_p8),
-    'xcit_large_24_p8': lambda: basenetworks.XCiT('xcit_large_24_p8', xcit_net=xcit.xcit_large_24_p8),
-
+    # Swin architectures: swin_t is roughly equivalent to unmodified resnet50
+    'swin_t': lambda: basenetworks.SwinTransformer(
+        'swin_t', swin_transformer.swin_tiny_patch4_window7),
+    'swin_s': lambda: basenetworks.SwinTransformer(
+        'swin_s', swin_transformer.swin_small_patch4_window7),
+    'swin_b': lambda: basenetworks.SwinTransformer(
+        'swin_b', swin_transformer.swin_base_patch4_window7),
+    # XCiT architectures: xcit_small_12_p16 is roughly equivalent to unmodified resnet50
+    'xcit_nano_12_p16': lambda: basenetworks.XCiT('xcit_nano_12_p16', xcit.xcit_nano_12_p16),
+    'xcit_tiny_12_p16': lambda: basenetworks.XCiT('xcit_tiny_12_p16', xcit.xcit_tiny_12_p16),
+    'xcit_tiny_24_p16': lambda: basenetworks.XCiT('xcit_tiny_24_p16', xcit.xcit_tiny_24_p16),
+    'xcit_small_12_p16': lambda: basenetworks.XCiT('xcit_small_12_p16', xcit.xcit_small_12_p16),
+    'xcit_small_24_p16': lambda: basenetworks.XCiT('xcit_small_24_p16', xcit.xcit_small_24_p16),
+    'xcit_medium_24_p16': lambda: basenetworks.XCiT('xcit_medium_24_p16', xcit.xcit_medium_24_p16),
+    'xcit_large_24_p16': lambda: basenetworks.XCiT('xcit_large_24_p16', xcit.xcit_large_24_p16),
+    'xcit_nano_12_p8': lambda: basenetworks.XCiT('xcit_nano_12_p8', xcit.xcit_nano_12_p8),
+    'xcit_tiny_12_p8': lambda: basenetworks.XCiT('xcit_tiny_12_p8', xcit.xcit_tiny_12_p8),
+    'xcit_tiny_24_p8': lambda: basenetworks.XCiT('xcit_tiny_24_p8', xcit.xcit_tiny_24_p8),
+    'xcit_small_12_p8': lambda: basenetworks.XCiT('xcit_small_12_p8', xcit.xcit_small_12_p8),
+    'xcit_small_24_p8': lambda: basenetworks.XCiT('xcit_small_24_p8', xcit.xcit_small_24_p8),
+    'xcit_medium_24_p8': lambda: basenetworks.XCiT('xcit_medium_24_p8', xcit.xcit_medium_24_p8),
+    'xcit_large_24_p8': lambda: basenetworks.XCiT('xcit_large_24_p8', xcit.xcit_large_24_p8),
 }
 
 #: headmeta class to head class

--- a/openpifpaf/network/swin_transformer.py
+++ b/openpifpaf/network/swin_transformer.py
@@ -1,0 +1,676 @@
+# --------------------------------------------------------
+# Swin Transformer
+# Copyright (c) 2021 Microsoft
+# Licensed under The MIT License [see LICENSE for details]
+# Written by Ze Liu, Yutong Lin, Yixuan Wei
+# --------------------------------------------------------
+# Refactoring and addition of output feature maps and pretrained model loading by David Mizrahi
+# --------------------------------------------------------
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+import torch.utils.checkpoint as checkpoint
+import numpy as np
+from timm.models.layers import DropPath, to_2tuple, trunc_normal_
+
+
+class Mlp(nn.Module):
+    """ Multilayer perceptron."""
+
+    def __init__(self, in_features, hidden_features=None, out_features=None, act_layer=nn.GELU, drop=0.):
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = nn.Linear(in_features, hidden_features)
+        self.act = act_layer()
+        self.fc2 = nn.Linear(hidden_features, out_features)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x
+
+
+def window_partition(x, window_size):
+    """
+    Args:
+        x: (B, H, W, C)
+        window_size (int): window size
+    Returns:
+        windows: (num_windows*B, window_size, window_size, C)
+    """
+    B, H, W, C = x.shape
+    x = x.view(B, H // window_size, window_size, W // window_size, window_size, C)
+    windows = x.permute(0, 1, 3, 2, 4, 5).contiguous().view(-1, window_size, window_size, C)
+    return windows
+
+
+def window_reverse(windows, window_size, H, W):
+    """
+    Args:
+        windows: (num_windows*B, window_size, window_size, C)
+        window_size (int): Window size
+        H (int): Height of image
+        W (int): Width of image
+    Returns:
+        x: (B, H, W, C)
+    """
+    B = int(windows.shape[0] / (H * W / window_size / window_size))
+    x = windows.view(B, H // window_size, W // window_size, window_size, window_size, -1)
+    x = x.permute(0, 1, 3, 2, 4, 5).contiguous().view(B, H, W, -1)
+    return x
+
+
+class WindowAttention(nn.Module):
+    """ Window based multi-head self attention (W-MSA) module with relative position bias.
+    It supports both of shifted and non-shifted window.
+    Args:
+        dim (int): Number of input channels.
+        window_size (tuple[int]): The height and width of the window.
+        num_heads (int): Number of attention heads.
+        qkv_bias (bool, optional):  If True, add a learnable bias to query, key, value. Default: True
+        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set
+        attn_drop (float, optional): Dropout ratio of attention weight. Default: 0.0
+        proj_drop (float, optional): Dropout ratio of output. Default: 0.0
+    """
+
+    def __init__(self, dim, window_size, num_heads, qkv_bias=True, qk_scale=None, attn_drop=0., proj_drop=0.):
+
+        super().__init__()
+        self.dim = dim
+        self.window_size = window_size  # Wh, Ww
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim ** -0.5
+
+        # define a parameter table of relative position bias
+        self.relative_position_bias_table = nn.Parameter(
+            torch.zeros((2 * window_size[0] - 1) * (2 * window_size[1] - 1), num_heads))  # 2*Wh-1 * 2*Ww-1, nH
+
+        # get pair-wise relative position index for each token inside the window
+        coords_h = torch.arange(self.window_size[0])
+        coords_w = torch.arange(self.window_size[1])
+        coords = torch.stack(torch.meshgrid([coords_h, coords_w]))  # 2, Wh, Ww
+        coords_flatten = torch.flatten(coords, 1)  # 2, Wh*Ww
+        relative_coords = coords_flatten[:, :, None] - coords_flatten[:, None, :]  # 2, Wh*Ww, Wh*Ww
+        relative_coords = relative_coords.permute(1, 2, 0).contiguous()  # Wh*Ww, Wh*Ww, 2
+        relative_coords[:, :, 0] += self.window_size[0] - 1  # shift to start from 0
+        relative_coords[:, :, 1] += self.window_size[1] - 1
+        relative_coords[:, :, 0] *= 2 * self.window_size[1] - 1
+        relative_position_index = relative_coords.sum(-1)  # Wh*Ww, Wh*Ww
+        self.register_buffer("relative_position_index", relative_position_index)
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+        trunc_normal_(self.relative_position_bias_table, std=.02)
+        self.softmax = nn.Softmax(dim=-1)
+
+    def forward(self, x, mask=None):
+        """ Forward function.
+        Args:
+            x: input features with shape of (num_windows*B, N, C)
+            mask: (0/-inf) mask with shape of (num_windows, Wh*Ww, Wh*Ww) or None
+        """
+        B_, N, C = x.shape
+        qkv = self.qkv(x).reshape(B_, N, 3, self.num_heads, C // self.num_heads).permute(2, 0, 3, 1, 4)
+        q, k, v = qkv[0], qkv[1], qkv[2]  # make torchscript happy (cannot use tensor as tuple)
+
+        q = q * self.scale
+        attn = (q @ k.transpose(-2, -1))
+
+        relative_position_bias = self.relative_position_bias_table[self.relative_position_index.view(-1)].view(
+            self.window_size[0] * self.window_size[1], self.window_size[0] * self.window_size[1], -1)  # Wh*Ww,Wh*Ww,nH
+        relative_position_bias = relative_position_bias.permute(2, 0, 1).contiguous()  # nH, Wh*Ww, Wh*Ww
+        attn = attn + relative_position_bias.unsqueeze(0)
+
+        if mask is not None:
+            nW = mask.shape[0]
+            attn = attn.view(B_ // nW, nW, self.num_heads, N, N) + mask.unsqueeze(1).unsqueeze(0)
+            attn = attn.view(-1, self.num_heads, N, N)
+            attn = self.softmax(attn)
+        else:
+            attn = self.softmax(attn)
+
+        attn = self.attn_drop(attn)
+
+        x = (attn @ v).transpose(1, 2).reshape(B_, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+
+class SwinTransformerBlock(nn.Module):
+    """ Swin Transformer Block.
+    Args:
+        dim (int): Number of input channels.
+        num_heads (int): Number of attention heads.
+        window_size (int): Window size.
+        shift_size (int): Shift size for SW-MSA.
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim.
+        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
+        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set.
+        drop (float, optional): Dropout rate. Default: 0.0
+        attn_drop (float, optional): Attention dropout rate. Default: 0.0
+        drop_path (float, optional): Stochastic depth rate. Default: 0.0
+        act_layer (nn.Module, optional): Activation layer. Default: nn.GELU
+        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+    """
+
+    def __init__(self, dim, num_heads, window_size=7, shift_size=0,
+                 mlp_ratio=4., qkv_bias=True, qk_scale=None, drop=0., attn_drop=0., drop_path=0.,
+                 act_layer=nn.GELU, norm_layer=nn.LayerNorm):
+        super().__init__()
+        self.dim = dim
+        self.num_heads = num_heads
+        self.window_size = window_size
+        self.shift_size = shift_size
+        self.mlp_ratio = mlp_ratio
+        assert 0 <= self.shift_size < self.window_size, "shift_size must in 0-window_size"
+
+        self.norm1 = norm_layer(dim)
+        self.attn = WindowAttention(
+            dim, window_size=to_2tuple(self.window_size), num_heads=num_heads,
+            qkv_bias=qkv_bias, qk_scale=qk_scale, attn_drop=attn_drop, proj_drop=drop)
+
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+        self.norm2 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer, drop=drop)
+
+        self.H = None
+        self.W = None
+
+    def forward(self, x, mask_matrix):
+        """ Forward function.
+        Args:
+            x: Input feature, tensor size (B, H*W, C).
+            H, W: Spatial resolution of the input feature.
+            mask_matrix: Attention mask for cyclic shift.
+        """
+        B, L, C = x.shape
+        H, W = self.H, self.W
+        assert L == H * W, "input feature has wrong size"
+
+        shortcut = x
+        x = self.norm1(x)
+        x = x.view(B, H, W, C)
+
+        # pad feature maps to multiples of window size
+        pad_l = pad_t = 0
+        pad_r = (self.window_size - W % self.window_size) % self.window_size
+        pad_b = (self.window_size - H % self.window_size) % self.window_size
+        x = F.pad(x, (0, 0, pad_l, pad_r, pad_t, pad_b))
+        _, Hp, Wp, _ = x.shape
+
+        # cyclic shift
+        if self.shift_size > 0:
+            shifted_x = torch.roll(x, shifts=(-self.shift_size, -self.shift_size), dims=(1, 2))
+            attn_mask = mask_matrix
+        else:
+            shifted_x = x
+            attn_mask = None
+
+        # partition windows
+        x_windows = window_partition(shifted_x, self.window_size)  # nW*B, window_size, window_size, C
+        x_windows = x_windows.view(-1, self.window_size * self.window_size, C)  # nW*B, window_size*window_size, C
+
+        # W-MSA/SW-MSA
+        attn_windows = self.attn(x_windows, mask=attn_mask)  # nW*B, window_size*window_size, C
+
+        # merge windows
+        attn_windows = attn_windows.view(-1, self.window_size, self.window_size, C)
+        shifted_x = window_reverse(attn_windows, self.window_size, Hp, Wp)  # B H' W' C
+
+        # reverse cyclic shift
+        if self.shift_size > 0:
+            x = torch.roll(shifted_x, shifts=(self.shift_size, self.shift_size), dims=(1, 2))
+        else:
+            x = shifted_x
+
+        if pad_r > 0 or pad_b > 0:
+            x = x[:, :H, :W, :].contiguous()
+
+        x = x.view(B, H * W, C)
+
+        # FFN
+        x = shortcut + self.drop_path(x)
+        x = x + self.drop_path(self.mlp(self.norm2(x)))
+
+        return x
+
+
+class PatchMerging(nn.Module):
+    """ Patch Merging Layer
+    Args:
+        dim (int): Number of input channels.
+        norm_layer (nn.Module, optional): Normalization layer.  Default: nn.LayerNorm
+    """
+
+    def __init__(self, dim, norm_layer=nn.LayerNorm):
+        super().__init__()
+        self.dim = dim
+        self.reduction = nn.Linear(4 * dim, 2 * dim, bias=False)
+        self.norm = norm_layer(4 * dim)
+
+    def forward(self, x, H, W):
+        """ Forward function.
+        Args:
+            x: Input feature, tensor size (B, H*W, C).
+            H, W: Spatial resolution of the input feature.
+        """
+        B, L, C = x.shape
+        assert L == H * W, "input feature has wrong size"
+
+        x = x.view(B, H, W, C)
+
+        # padding
+        pad_input = (H % 2 == 1) or (W % 2 == 1)
+        if pad_input:
+            x = F.pad(x, (0, 0, 0, W % 2, 0, H % 2))
+
+        x0 = x[:, 0::2, 0::2, :]  # B H/2 W/2 C
+        x1 = x[:, 1::2, 0::2, :]  # B H/2 W/2 C
+        x2 = x[:, 0::2, 1::2, :]  # B H/2 W/2 C
+        x3 = x[:, 1::2, 1::2, :]  # B H/2 W/2 C
+        x = torch.cat([x0, x1, x2, x3], -1)  # B H/2 W/2 4*C
+        x = x.view(B, -1, 4 * C)  # B H/2*W/2 4*C
+
+        x = self.norm(x)
+        x = self.reduction(x)
+
+        return x
+
+
+class BasicLayer(nn.Module):
+    """ A basic Swin Transformer layer for one stage.
+    Args:
+        dim (int): Number of feature channels
+        depth (int): Depths of this stage.
+        num_heads (int): Number of attention head.
+        window_size (int): Local window size. Default: 7.
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: 4.
+        qkv_bias (bool, optional): If True, add a learnable bias to query, key, value. Default: True
+        qk_scale (float | None, optional): Override default qk scale of head_dim ** -0.5 if set.
+        drop (float, optional): Dropout rate. Default: 0.0
+        attn_drop (float, optional): Attention dropout rate. Default: 0.0
+        drop_path (float | tuple[float], optional): Stochastic depth rate. Default: 0.0
+        norm_layer (nn.Module, optional): Normalization layer. Default: nn.LayerNorm
+        downsample (nn.Module | None, optional): Downsample layer at the end of the layer. Default: None
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False.
+    """
+
+    def __init__(self,
+                 dim,
+                 depth,
+                 num_heads,
+                 window_size=7,
+                 mlp_ratio=4.,
+                 qkv_bias=True,
+                 qk_scale=None,
+                 drop=0.,
+                 attn_drop=0.,
+                 drop_path=0.,
+                 norm_layer=nn.LayerNorm,
+                 downsample=None,
+                 use_checkpoint=False):
+        super().__init__()
+        self.window_size = window_size
+        self.shift_size = window_size // 2
+        self.depth = depth
+        self.use_checkpoint = use_checkpoint
+
+        # build blocks
+        self.blocks = nn.ModuleList([
+            SwinTransformerBlock(
+                dim=dim,
+                num_heads=num_heads,
+                window_size=window_size,
+                shift_size=0 if (i % 2 == 0) else window_size // 2,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                qk_scale=qk_scale,
+                drop=drop,
+                attn_drop=attn_drop,
+                drop_path=drop_path[i] if isinstance(drop_path, list) else drop_path,
+                norm_layer=norm_layer)
+            for i in range(depth)])
+
+        # patch merging layer
+        if downsample is not None:
+            self.downsample = downsample(dim=dim, norm_layer=norm_layer)
+        else:
+            self.downsample = None
+
+    def forward(self, x, H, W):
+        """ Forward function.
+        Args:
+            x: Input feature, tensor size (B, H*W, C).
+            H, W: Spatial resolution of the input feature.
+        """
+
+        # calculate attention mask for SW-MSA
+        Hp = int(np.ceil(H / self.window_size)) * self.window_size
+        Wp = int(np.ceil(W / self.window_size)) * self.window_size
+        img_mask = torch.zeros((1, Hp, Wp, 1), device=x.device)  # 1 Hp Wp 1
+        h_slices = (slice(0, -self.window_size),
+                    slice(-self.window_size, -self.shift_size),
+                    slice(-self.shift_size, None))
+        w_slices = (slice(0, -self.window_size),
+                    slice(-self.window_size, -self.shift_size),
+                    slice(-self.shift_size, None))
+        cnt = 0
+        for h in h_slices:
+            for w in w_slices:
+                img_mask[:, h, w, :] = cnt
+                cnt += 1
+
+        mask_windows = window_partition(img_mask, self.window_size)  # nW, window_size, window_size, 1
+        mask_windows = mask_windows.view(-1, self.window_size * self.window_size)
+        attn_mask = mask_windows.unsqueeze(1) - mask_windows.unsqueeze(2)
+        attn_mask = attn_mask.masked_fill(attn_mask != 0, float(-100.0)).masked_fill(attn_mask == 0, float(0.0))
+
+        for blk in self.blocks:
+            blk.H, blk.W = H, W
+            if self.use_checkpoint:
+                x = checkpoint.checkpoint(blk, x, attn_mask)
+            else:
+                x = blk(x, attn_mask)
+        if self.downsample is not None:
+            x_down = self.downsample(x, H, W)
+            Wh, Ww = (H + 1) // 2, (W + 1) // 2
+            return x, H, W, x_down, Wh, Ww
+        else:
+            return x, H, W, x, H, W
+
+
+class PatchEmbed(nn.Module):
+    """ Image to Patch Embedding
+    Args:
+        patch_size (int): Patch token size. Default: 4.
+        in_chans (int): Number of input image channels. Default: 3.
+        embed_dim (int): Number of linear projection output channels. Default: 96.
+        norm_layer (nn.Module, optional): Normalization layer. Default: None
+    """
+
+    def __init__(self, patch_size=4, in_chans=3, embed_dim=96, norm_layer=None):
+        super().__init__()
+        patch_size = to_2tuple(patch_size)
+        self.patch_size = patch_size
+
+        self.in_chans = in_chans
+        self.embed_dim = embed_dim
+
+        self.proj = nn.Conv2d(in_chans, embed_dim, kernel_size=patch_size, stride=patch_size)
+        if norm_layer is not None:
+            self.norm = norm_layer(embed_dim)
+        else:
+            self.norm = None
+
+    def forward(self, x):
+        """Forward function."""
+        # padding
+        _, _, H, W = x.size()
+        if W % self.patch_size[1] != 0:
+            x = F.pad(x, (0, self.patch_size[1] - W % self.patch_size[1]))
+        if H % self.patch_size[0] != 0:
+            x = F.pad(x, (0, 0, 0, self.patch_size[0] - H % self.patch_size[0]))
+
+        x = self.proj(x)  # B C Wh Ww
+        if self.norm is not None:
+            Wh, Ww = x.size(2), x.size(3)
+            x = x.flatten(2).transpose(1, 2)
+            x = self.norm(x)
+            x = x.transpose(1, 2).view(-1, self.embed_dim, Wh, Ww)
+
+        return x
+
+
+class SwinTransformer(nn.Module):
+    """ Swin Transformer backbone.
+        A PyTorch impl of : `Swin Transformer: Hierarchical Vision Transformer using Shifted Windows`  -
+          https://arxiv.org/pdf/2103.14030
+    Args:
+        pretrain_img_size (int): Input image size for training the pretrained model,
+            used in absolute postion embedding. Default 224.
+        patch_size (int | tuple(int)): Patch size. Default: 4.
+        in_chans (int): Number of input image channels. Default: 3.
+        embed_dim (int): Number of linear projection output channels. Default: 96.
+        depths (tuple[int]): Depths of each Swin Transformer stage.
+        num_heads (tuple[int]): Number of attention head of each stage.
+        window_size (int): Window size. Default: 7.
+        mlp_ratio (float): Ratio of mlp hidden dim to embedding dim. Default: 4.
+        qkv_bias (bool): If True, add a learnable bias to query, key, value. Default: True
+        qk_scale (float): Override default qk scale of head_dim ** -0.5 if set.
+        drop_rate (float): Dropout rate.
+        attn_drop_rate (float): Attention dropout rate. Default: 0.
+        drop_path_rate (float): Stochastic depth rate. Default: 0.2.
+        norm_layer (nn.Module): Normalization layer. Default: nn.LayerNorm.
+        ape (bool): If True, add absolute position embedding to the patch embedding. Default: False.
+        patch_norm (bool): If True, add normalization after patch embedding. Default: True.
+        use_fpn (bool): If True, outputs FPN, otherwise, outputs a single feature map
+        out_indices (Sequence[int]): Output from which stages (for FPN)
+        frozen_stages (int): Stages to be frozen (stop grad and set eval mode).
+            -1 means not freezing any parameters.
+        use_checkpoint (bool): Whether to use checkpointing to save memory. Default: False.
+        out_dim (int): Output dimension if no FPN
+    """
+
+    def __init__(self,
+                 pretrain_img_size=224,
+                 patch_size=4,
+                 in_chans=3,
+                 embed_dim=96,
+                 depths=[2, 2, 6, 2],
+                 num_heads=[3, 6, 12, 24],
+                 window_size=7,
+                 mlp_ratio=4.,
+                 qkv_bias=True,
+                 qk_scale=None,
+                 drop_rate=0.,
+                 attn_drop_rate=0.,
+                 drop_path_rate=0.2,
+                 norm_layer=nn.LayerNorm,
+                 ape=False,
+                 patch_norm=True,
+                 use_fpn=False,
+                 out_indices=(0, 1, 2, 3),
+                 frozen_stages=-1,
+                 use_checkpoint=False,
+                 out_dim=2048):
+        super().__init__()
+
+        self.pretrain_img_size = pretrain_img_size
+        self.num_layers = len(depths)
+        self.embed_dim = embed_dim
+        self.ape = ape
+        self.patch_norm = patch_norm
+        self.out_indices = out_indices
+        self.frozen_stages = frozen_stages
+        self.use_fpn = use_fpn
+
+        # split image into non-overlapping patches
+        self.patch_embed = PatchEmbed(
+            patch_size=patch_size, in_chans=in_chans, embed_dim=embed_dim,
+            norm_layer=norm_layer if self.patch_norm else None)
+
+        # absolute position embedding
+        if self.ape:
+            pretrain_img_size = to_2tuple(pretrain_img_size)
+            patch_size = to_2tuple(patch_size)
+            patches_resolution = [pretrain_img_size[0] // patch_size[0], pretrain_img_size[1] // patch_size[1]]
+
+            self.absolute_pos_embed = nn.Parameter(
+                torch.zeros(1, embed_dim, patches_resolution[0], patches_resolution[1]))
+            trunc_normal_(self.absolute_pos_embed, std=.02)
+
+        self.pos_drop = nn.Dropout(p=drop_rate)
+
+        # stochastic depth
+        dpr = [x.item() for x in torch.linspace(0, drop_path_rate, sum(depths))]  # stochastic depth decay rule
+
+        # build layers
+        self.layers = nn.ModuleList()
+        for i_layer in range(self.num_layers):
+            layer = BasicLayer(
+                dim=int(embed_dim * 2 ** i_layer),
+                depth=depths[i_layer],
+                num_heads=num_heads[i_layer],
+                window_size=window_size,
+                mlp_ratio=mlp_ratio,
+                qkv_bias=qkv_bias,
+                qk_scale=qk_scale,
+                drop=drop_rate,
+                attn_drop=attn_drop_rate,
+                drop_path=dpr[sum(depths[:i_layer]):sum(depths[:i_layer + 1])],
+                norm_layer=norm_layer,
+                downsample=PatchMerging if (i_layer < self.num_layers - 1) else None,
+                use_checkpoint=use_checkpoint)
+            self.layers.append(layer)
+
+        num_features = [int(embed_dim * 2 ** i) for i in range(self.num_layers)]
+        self.num_features = num_features
+
+        # add a norm layer for each output
+        for i_layer in out_indices:
+            layer = norm_layer(num_features[i_layer])
+            layer_name = f'norm{i_layer}'
+            self.add_module(layer_name, layer)
+
+        # No FPN layers
+        if not self.use_fpn:
+            self.upsample = nn.Sequential(
+                nn.ConvTranspose2d(8 * embed_dim, 8 * embed_dim, kernel_size=2, stride=2)
+            )
+            self.project = nn.Conv2d(4 * embed_dim, 8 * embed_dim, kernel_size=1, stride=1)
+            self.out_projection = nn.Conv2d(8 * embed_dim, out_dim, kernel_size=1, stride=1)
+
+        self._freeze_stages()
+
+    def _freeze_stages(self):
+        if self.frozen_stages >= 0:
+            self.patch_embed.eval()
+            for param in self.patch_embed.parameters():
+                param.requires_grad = False
+
+        if self.frozen_stages >= 1 and self.ape:
+            self.absolute_pos_embed.requires_grad = False
+
+        if self.frozen_stages >= 2:
+            self.pos_drop.eval()
+            for i in range(0, self.frozen_stages - 1):
+                m = self.layers[i]
+                m.eval()
+                for param in m.parameters():
+                    param.requires_grad = False
+
+    def init_weights(self, pretrained=None, strict=False):
+        """Initialize the weights in backbone.
+        Args:
+            pretrained (str, optional): Path to pre-trained weights.
+                Defaults to None.
+            strict (bool): whether to strictly enforce that the keys in state_dict
+                match the keys returned by this module’s state_dict() function.
+                Defaults to False.
+        """
+        def _init_weights(m):
+            if isinstance(m, nn.Linear):
+                trunc_normal_(m.weight, std=.02)
+                if isinstance(m, nn.Linear) and m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.LayerNorm):
+                nn.init.constant_(m.bias, 0)
+                nn.init.constant_(m.weight, 1.0)
+
+        if isinstance(pretrained, str):
+            self.apply(_init_weights)
+
+            if pretrained.startswith('https'):
+                checkpoint = torch.hub.load_state_dict_from_url(pretrained, map_location='cpu')
+            else:
+                checkpoint = torch.load(pretrained, map_location='cpu')
+
+            checkpoint_model = checkpoint['model']
+            missing_keys = self.load_state_dict(checkpoint_model, strict=strict)
+            # Uncomment to print missing_keys
+            # print(missing_keys)
+
+        elif pretrained is None:
+            self.apply(_init_weights)
+        else:
+            raise TypeError('pretrained must be a str or None')
+
+    def forward(self, x):
+        """Forward function."""
+        x = self.patch_embed(x)
+
+        Wh, Ww = x.size(2), x.size(3)
+        if self.ape:
+            # interpolate the position embedding to the corresponding size
+            absolute_pos_embed = F.interpolate(self.absolute_pos_embed, size=(Wh, Ww), mode='bicubic')
+            x = (x + absolute_pos_embed).flatten(2).transpose(1, 2)  # B Wh*Ww C
+        else:
+            x = x.flatten(2).transpose(1, 2)
+        x = self.pos_drop(x)
+
+        outs = []
+        for i in range(self.num_layers):
+            layer = self.layers[i]
+            x_out, H, W, x, Wh, Ww = layer(x, Wh, Ww)
+
+            if i in self.out_indices:
+                norm_layer = getattr(self, f'norm{i}')
+                x_out = norm_layer(x_out)
+
+                out = x_out.view(-1, H, W, self.num_features[i]).permute(0, 3, 1, 2).contiguous()
+                outs.append(out)
+
+        if self.use_fpn:
+            return tuple(outs)
+        else:
+            out = self.upsample(outs[-1])
+            # Add the two feature maps
+            out = out + self.project(outs[-2])
+            # Project to 2048 channels
+            out = self.out_projection(out)
+            return out
+
+    def train(self, mode=True):
+        """Convert the model into training mode while keep layers freezed."""
+        super(SwinTransformer, self).train(mode)
+        self._freeze_stages()
+
+
+def swin_tiny_patch4_window7(pretrained=True, **kwargs):
+    model = SwinTransformer(embed_dim=96, depths=(2, 2, 6, 2), num_heads=(3, 6, 12, 24),
+                            window_size=7, ape=False, drop_path_rate=0.2, patch_norm=True,
+                            use_checkpoint=False, **kwargs)
+    url = "https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_tiny_patch4_window7_224.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def swin_small_patch4_window7(pretrained=True, **kwargs):
+    model = SwinTransformer(embed_dim=96, depths=(2, 2, 18, 2), num_heads=(3, 6, 12, 24),
+                            window_size=7, ape=False, drop_path_rate=0.2, patch_norm=True,
+                            use_checkpoint=False, **kwargs)
+    url = "https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_small_patch4_window7_224.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def swin_base_patch4_window7(pretrained=True, **kwargs):
+    model = SwinTransformer(embed_dim=128, depths=(2, 2, 18, 2), num_heads=(4, 8, 16, 32),
+                            window_size=7, ape=False, drop_path_rate=0.2, patch_norm=True,
+                            use_checkpoint=False, **kwargs)
+    # Note: For Swin-B, 384x384x ImageNet-1K pretraining and ImageNet-22K pretraining is also available
+    url = "https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_base_patch4_window7_224.pth"
+    model.init_weights(url if pretrained else None)
+    return model

--- a/openpifpaf/network/swin_transformer.py
+++ b/openpifpaf/network/swin_transformer.py
@@ -546,9 +546,8 @@ class SwinTransformer(nn.Module):
 
         # No FPN layers
         if not self.use_fpn:
-            self.upsample = nn.Sequential(
-                nn.ConvTranspose2d(8 * embed_dim, 8 * embed_dim, kernel_size=2, stride=2)
-            )
+            # Change kernel_size and padding to work with uneven downscaling
+            self.upsample = nn.ConvTranspose2d(8 * embed_dim, 8 * embed_dim, kernel_size=3, stride=2, padding=1)
             self.project = nn.Conv2d(4 * embed_dim, 8 * embed_dim, kernel_size=1, stride=1)
             self.out_projection = nn.Conv2d(8 * embed_dim, out_dim, kernel_size=1, stride=1)
 
@@ -635,7 +634,7 @@ class SwinTransformer(nn.Module):
         if self.use_fpn:
             return tuple(outs)
         else:
-            out = self.upsample(outs[-1])
+            out = self.upsample(outs[-1], output_size=outs[-2].shape)
             # Add the two feature maps
             out = out + self.project(outs[-2])
             # Project to 2048 channels

--- a/openpifpaf/network/swin_transformer.py
+++ b/openpifpaf/network/swin_transformer.py
@@ -21,8 +21,6 @@ except ImportError:
     pass
 
 
-
-
 class Mlp(nn.Module):
     """ Multilayer perceptron."""
 

--- a/openpifpaf/network/swin_transformer.py
+++ b/openpifpaf/network/swin_transformer.py
@@ -14,7 +14,13 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
 import numpy as np
-from timm.models.layers import DropPath, to_2tuple, trunc_normal_
+
+try:
+    from timm.models.layers import DropPath, to_2tuple, trunc_normal_
+except ImportError:
+    pass
+
+
 
 
 class Mlp(nn.Module):

--- a/openpifpaf/network/swin_transformer.py
+++ b/openpifpaf/network/swin_transformer.py
@@ -545,6 +545,7 @@ class SwinTransformer(nn.Module):
             self.add_module(layer_name, layer)
 
         # No FPN layers
+        # Upsampling + out projection added, not in original implementation
         if not self.use_fpn:
             # Change kernel_size and padding to work with uneven downscaling
             self.upsample = nn.ConvTranspose2d(8 * embed_dim, 8 * embed_dim, kernel_size=3, stride=2, padding=1)

--- a/openpifpaf/network/swin_transformer.py
+++ b/openpifpaf/network/swin_transformer.py
@@ -1,7 +1,7 @@
 # --------------------------------------------------------
 # Swin Transformer
 # Copyright (c) 2021 Microsoft
-# Licensed under The MIT License
+# Licensed under The MIT License [see docs/LICENSE.SWIN for details]
 # Written by Ze Liu, Yutong Lin, Yixuan Wei
 # --------------------------------------------------------
 # Refactoring and loading of pretrained model weights by David Mizrahi

--- a/openpifpaf/network/swin_transformer.py
+++ b/openpifpaf/network/swin_transformer.py
@@ -6,6 +6,8 @@
 # --------------------------------------------------------
 # Refactoring and loading of pretrained model weights by David Mizrahi
 # --------------------------------------------------------
+# pylint: skip-file
+
 
 import torch
 import torch.nn as nn

--- a/openpifpaf/network/xcit.py
+++ b/openpifpaf/network/xcit.py
@@ -10,6 +10,7 @@ Paper:
 # Refactoring, modifications to class arguments and
 # loading of pretrained model weights by David Mizrahi
 # --------------------------------------------------------
+# pylint: skip-file
 
 import math
 from functools import partial

--- a/openpifpaf/network/xcit.py
+++ b/openpifpaf/network/xcit.py
@@ -1,5 +1,5 @@
 """ Cross-Covariance Image Transformer (XCiT) in PyTorch
-Same as the official implementation, with some                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           adaptations.
+Same as the official implementation, with some minor adaptations.
     - https://github.com/facebookresearch/xcit/blob/master/detection/backbone/xcit.py
 Paper:
     - https://arxiv.org/abs/2106.09681
@@ -139,6 +139,7 @@ class LPI(nn.Module):
 
         return x
 
+
 # Not used for dense feature maps
 class ClassAttention(nn.Module):
     """Class Attention Layer as in CaiT https://arxiv.org/abs/2103.17239
@@ -171,6 +172,7 @@ class ClassAttention(nn.Module):
         x = torch.cat([self.proj_drop(cls_tkn), x[:, 1:]], dim=1)
         return x
 
+
 # Not used for dense feature maps
 class ClassAttentionBlock(nn.Module):
     """Class Attention Layer as in CaiT https://arxiv.org/abs/2103.17239
@@ -199,7 +201,6 @@ class ClassAttentionBlock(nn.Module):
         else:
             self.gamma1, self.gamma2 = 1.0, 1.0
 
-        # FIXME: A hack for models pre-trained with layernorm over all the tokens not just the CLS
         self.tokens_norm = tokens_norm
 
     def forward(self, x, H, W, mask=None):
@@ -318,7 +319,7 @@ class XCiT(nn.Module):
             cls_attn_layers: (int) Depth of Class attention layers (not used for dense feature maps)
             use_pos: (bool) whether to use positional encoding
             eta: (float) layerscale initialization value
-            tokens_norm: (bool) Whether to normalize all tokens or just the cls_token in the CA (not used for dense feature maps)
+            tokens_norm: (bool) Whether to normalize all tokens or just the cls_token in the CA (not used)
             use_fpn: (bool) if True, use FPN features
             out_indices: (list) Indices of layers from which FPN features are extracted
             out_dim: (int) Output dimension if no FPN is used
@@ -544,6 +545,7 @@ def xcit_large_24_p16(pretrained=True, **kwargs):
     url = "https://dl.fbaipublicfiles.com/xcit/xcit_large_24_p16_384_dist.pth"
     model.init_weights(url if pretrained else None)
     return model
+
 
 # Patch size 8x8 models
 def xcit_nano_12_p8(pretrained=True, **kwargs):

--- a/openpifpaf/network/xcit.py
+++ b/openpifpaf/network/xcit.py
@@ -6,6 +6,7 @@ Paper:
 """
 # Copyright (c) 2015-present, Facebook, Inc.
 # All rights reserved.
+# Licensed under The Apache-2.0 License [see docs/LICENSE.XCIT for details]
 # --------------------------------------------------------
 # Refactoring, modifications to class arguments and
 # loading of pretrained model weights by David Mizrahi

--- a/openpifpaf/network/xcit.py
+++ b/openpifpaf/network/xcit.py
@@ -356,7 +356,7 @@ class XCiT(nn.Module):
             elif patch_size == 8:
                 self.out_projection = nn.Sequential(
                     nn.Conv2d(embed_dim, out_dim, kernel_size=1, stride=1),
-                    nn.MaxPool2d(kernel_size=2, stride=2),
+                    nn.MaxPool2d(kernel_size=2, stride=2, ceil_mode=True),
                 )
             else:
                 raise ValueError("Invalid patch size for network")

--- a/openpifpaf/network/xcit.py
+++ b/openpifpaf/network/xcit.py
@@ -19,8 +19,11 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from timm.models.vision_transformer import Mlp
-from timm.models.layers import DropPath, trunc_normal_, to_2tuple
+try:
+    from timm.models.vision_transformer import Mlp
+    from timm.models.layers import DropPath, trunc_normal_, to_2tuple
+except ImportError:
+    pass
 
 
 class PositionalEncodingFourier(nn.Module):

--- a/openpifpaf/network/xcit.py
+++ b/openpifpaf/network/xcit.py
@@ -1,0 +1,534 @@
+""" Cross-Covariance Image Transformer (XCiT) in PyTorch
+Same as the official implementation, with some                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           adaptations.
+    - https://github.com/facebookresearch/xcit/blob/master/detection/backbone/xcit.py
+Paper:
+    - https://arxiv.org/abs/2106.09681
+"""
+# Copyright (c) 2015-present, Facebook, Inc.
+# All rights reserved.
+# --------------------------------------------------------
+# Refactoring, modifications to class arguments, and addition of output feature maps
+# and pretrained model loading added by David Mizrahi
+# --------------------------------------------------------
+
+import math
+from functools import partial
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from timm.models.vision_transformer import Mlp
+from timm.models.layers import DropPath, trunc_normal_, to_2tuple
+
+
+class PositionalEncodingFourier(nn.Module):
+    """
+    Positional encoding relying on a fourier kernel matching the one used in the
+    "Attention is all of Need" paper. The implementation builds on DeTR code
+    https://github.com/facebookresearch/detr/blob/master/models/position_encoding.py
+    """
+
+    def __init__(self, hidden_dim=32, dim=768, temperature=10000):
+        super().__init__()
+        self.token_projection = nn.Conv2d(hidden_dim * 2, dim, kernel_size=1)
+        self.scale = 2 * math.pi
+        self.temperature = temperature
+        self.hidden_dim = hidden_dim
+        self.dim = dim
+
+    def forward(self, B, H, W):
+        mask = torch.zeros(B, H, W).bool().to(self.token_projection.weight.device)
+        not_mask = ~mask
+        y_embed = not_mask.cumsum(1, dtype=torch.float32)
+        x_embed = not_mask.cumsum(2, dtype=torch.float32)
+        eps = 1e-6
+        y_embed = y_embed / (y_embed[:, -1:, :] + eps) * self.scale
+        x_embed = x_embed / (x_embed[:, :, -1:] + eps) * self.scale
+
+        dim_t = torch.arange(self.hidden_dim, dtype=torch.float32, device=mask.device)
+        dim_t = self.temperature ** (2 * (dim_t // 2) / self.hidden_dim)
+
+        pos_x = x_embed[:, :, :, None] / dim_t
+        pos_y = y_embed[:, :, :, None] / dim_t
+        pos_x = torch.stack((pos_x[:, :, :, 0::2].sin(),
+                             pos_x[:, :, :, 1::2].cos()), dim=4).flatten(3)
+        pos_y = torch.stack((pos_y[:, :, :, 0::2].sin(),
+                             pos_y[:, :, :, 1::2].cos()), dim=4).flatten(3)
+        pos = torch.cat((pos_y, pos_x), dim=3).permute(0, 3, 1, 2)
+        pos = self.token_projection(pos)
+        return pos
+
+
+def conv3x3(in_planes, out_planes, stride=1):
+    """3x3 convolution with padding"""
+    return torch.nn.Sequential(
+        nn.Conv2d(
+            in_planes, out_planes, kernel_size=3, stride=stride, padding=1, bias=False
+        ),
+        nn.BatchNorm2d(out_planes)
+    )
+
+
+class ConvPatchEmbed(nn.Module):
+    """ Image to Patch Embedding using multiple convolutional layers
+    """
+
+    def __init__(self, patch_size=16, embed_dim=768):
+        super().__init__()
+        patch_size = to_2tuple(patch_size)
+        self.patch_size = patch_size
+
+        if patch_size[0] == 16:
+            self.proj = torch.nn.Sequential(
+                conv3x3(3, embed_dim // 8, 2),
+                nn.GELU(),
+                conv3x3(embed_dim // 8, embed_dim // 4, 2),
+                nn.GELU(),
+                conv3x3(embed_dim // 4, embed_dim // 2, 2),
+                nn.GELU(),
+                conv3x3(embed_dim // 2, embed_dim, 2),
+            )
+        elif patch_size[0] == 8:
+            self.proj = torch.nn.Sequential(
+                conv3x3(3, embed_dim // 4, 2),
+                nn.GELU(),
+                conv3x3(embed_dim // 4, embed_dim // 2, 2),
+                nn.GELU(),
+                conv3x3(embed_dim // 2, embed_dim, 2),
+            )
+        else:
+            raise("For convolutional projection, patch size has to be in [8, 16]")
+
+    def forward(self, x):
+        x = self.proj(x)
+        Hp, Wp = x.shape[2], x.shape[3]
+        x = x.flatten(2).transpose(1, 2)
+
+        return x, (Hp, Wp)
+
+
+class LPI(nn.Module):
+    """
+    Local Patch Interaction module that allows explicit communication between tokens in 3x3 windows
+    to augment the implicit communcation performed by the block diagonal scatter attention.
+    Implemented using 2 layers of separable 3x3 convolutions with GeLU and BatchNorm2d
+    """
+
+    def __init__(self, in_features, out_features=None, act_layer=nn.GELU, kernel_size=3):
+        super().__init__()
+        out_features = out_features or in_features
+
+        padding = kernel_size // 2
+
+        self.conv1 = torch.nn.Conv2d(in_features, out_features, kernel_size=kernel_size,
+                                     padding=padding, groups=out_features)
+        self.act = act_layer()
+        self.bn = nn.BatchNorm2d(in_features)
+        self.conv2 = torch.nn.Conv2d(in_features, out_features, kernel_size=kernel_size,
+                                     padding=padding, groups=out_features)
+
+    def forward(self, x, H, W):
+        B, N, C = x.shape
+        x = x.permute(0, 2, 1).reshape(B, C, H, W)
+        x = self.conv1(x)
+        x = self.act(x)
+        x = self.bn(x)
+        x = self.conv2(x)
+        x = x.reshape(B, C, N).permute(0, 2, 1)
+
+        return x
+
+# Not used for dense feature maps
+class ClassAttention(nn.Module):
+    """Class Attention Layer as in CaiT https://arxiv.org/abs/2103.17239
+    """
+
+    def __init__(self, dim, num_heads=8, qkv_bias=False, qk_scale=None, attn_drop=0., proj_drop=0.):
+        super().__init__()
+        self.num_heads = num_heads
+        head_dim = dim // num_heads
+        self.scale = qk_scale or head_dim ** -0.5
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x):
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads)
+        qkv = qkv.permute(2, 0, 3, 1, 4)
+        q, k, v = qkv[0], qkv[1], qkv[2]   # make torchscript happy (cannot use tensor as tuple)
+
+        qc = q[:, :, 0:1]   # CLS token
+        attn_cls = (qc * k).sum(dim=-1) * self.scale
+        attn_cls = attn_cls.softmax(dim=-1)
+        attn_cls = self.attn_drop(attn_cls)
+
+        cls_tkn = (attn_cls.unsqueeze(2) @ v).transpose(1, 2).reshape(B, 1, C)
+        cls_tkn = self.proj(cls_tkn)
+        x = torch.cat([self.proj_drop(cls_tkn), x[:, 1:]], dim=1)
+        return x
+
+# Not used for dense feature maps
+class ClassAttentionBlock(nn.Module):
+    """Class Attention Layer as in CaiT https://arxiv.org/abs/2103.17239
+    """
+
+    def __init__(self, dim, num_heads, mlp_ratio=4., qkv_bias=False, qk_scale=None, drop=0.,
+                 attn_drop=0., drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm, eta=None,
+                 tokens_norm=False):
+        super().__init__()
+        self.norm1 = norm_layer(dim)
+
+        self.attn = ClassAttention(
+            dim, num_heads=num_heads, qkv_bias=qkv_bias, qk_scale=qk_scale, attn_drop=attn_drop,
+            proj_drop=drop
+        )
+
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+        self.norm2 = norm_layer(dim)
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer,
+                       drop=drop)
+
+        if eta is not None:     # LayerScale Initialization (no layerscale when None)
+            self.gamma1 = nn.Parameter(eta * torch.ones(dim), requires_grad=True)
+            self.gamma2 = nn.Parameter(eta * torch.ones(dim), requires_grad=True)
+        else:
+            self.gamma1, self.gamma2 = 1.0, 1.0
+
+        # FIXME: A hack for models pre-trained with layernorm over all the tokens not just the CLS
+        self.tokens_norm = tokens_norm
+
+    def forward(self, x, H, W, mask=None):
+        x = x + self.drop_path(self.gamma1 * self.attn(self.norm1(x)))
+        if self.tokens_norm:
+            x = self.norm2(x)
+        else:
+            x[:, 0:1] = self.norm2(x[:, 0:1])
+
+        x_res = x
+        cls_token = x[:, 0:1]
+        cls_token = self.gamma2 * self.mlp(cls_token)
+        x = torch.cat([cls_token, x[:, 1:]], dim=1)
+        x = x_res + self.drop_path(x)
+        return x
+
+
+class XCA(nn.Module):
+    """ Cross-Covariance Attention (XCA) operation where the channels are updated using a weighted
+     sum. The weights are obtained from the (softmax normalized) Cross-covariance
+    matrix (Q^T K \\in d_h \\times d_h)
+    """
+
+    def __init__(self, dim, num_heads=8, qkv_bias=False, qk_scale=None, attn_drop=0., proj_drop=0.):
+        super().__init__()
+        self.num_heads = num_heads
+        self.temperature = nn.Parameter(torch.ones(num_heads, 1, 1))
+
+        self.qkv = nn.Linear(dim, dim * 3, bias=qkv_bias)
+        self.attn_drop = nn.Dropout(attn_drop)
+        self.proj = nn.Linear(dim, dim)
+        self.proj_drop = nn.Dropout(proj_drop)
+
+    def forward(self, x):
+        B, N, C = x.shape
+        qkv = self.qkv(x).reshape(B, N, 3, self.num_heads, C // self.num_heads)
+        qkv = qkv.permute(2, 0, 3, 1, 4)
+        q, k, v = qkv[0], qkv[1], qkv[2]   # make torchscript happy (cannot use tensor as tuple)
+
+        q = q.transpose(-2, -1)
+        k = k.transpose(-2, -1)
+        v = v.transpose(-2, -1)
+
+        q = torch.nn.functional.normalize(q, dim=-1)
+        k = torch.nn.functional.normalize(k, dim=-1)
+
+        attn = (q @ k.transpose(-2, -1)) * self.temperature
+        attn = attn.softmax(dim=-1)
+        attn = self.attn_drop(attn)
+
+        x = (attn @ v).permute(0, 3, 1, 2).reshape(B, N, C)
+        x = self.proj(x)
+        x = self.proj_drop(x)
+        return x
+
+    @torch.jit.ignore
+    def no_weight_decay(self):
+        return {'temperature'}
+
+
+class XCABlock(nn.Module):
+    def __init__(self, dim, num_heads, mlp_ratio=4., qkv_bias=False, qk_scale=None, drop=0.,
+                 attn_drop=0., drop_path=0., act_layer=nn.GELU, norm_layer=nn.LayerNorm, eta=None):
+        super().__init__()
+        self.norm1 = norm_layer(dim)
+        self.attn = XCA(
+            dim, num_heads=num_heads, qkv_bias=qkv_bias, qk_scale=qk_scale, attn_drop=attn_drop,
+            proj_drop=drop
+        )
+        self.drop_path = DropPath(drop_path) if drop_path > 0. else nn.Identity()
+        self.norm2 = norm_layer(dim)
+
+        mlp_hidden_dim = int(dim * mlp_ratio)
+        self.mlp = Mlp(in_features=dim, hidden_features=mlp_hidden_dim, act_layer=act_layer,
+                       drop=drop)
+
+        self.norm3 = norm_layer(dim)
+        self.local_mp = LPI(in_features=dim, act_layer=act_layer)
+
+        self.gamma1 = nn.Parameter(eta * torch.ones(dim), requires_grad=True)
+        self.gamma2 = nn.Parameter(eta * torch.ones(dim), requires_grad=True)
+        self.gamma3 = nn.Parameter(eta * torch.ones(dim), requires_grad=True)
+
+    def forward(self, x, H, W):
+        x = x + self.drop_path(self.gamma1 * self.attn(self.norm1(x)))
+        x = x + self.drop_path(self.gamma3 * self.local_mp(self.norm3(x), H, W))
+        x = x + self.drop_path(self.gamma2 * self.mlp(self.norm2(x)))
+        return x
+
+
+class XCiT(nn.Module):
+    """ XCiT for dense tasks
+    Based on timm and DeiT code bases
+    https://github.com/rwightman/pytorch-image-models/tree/master/timm
+    https://github.com/facebookresearch/deit/
+    """
+
+    def __init__(self, patch_size=16, embed_dim=768,
+                 depth=12, num_heads=12, mlp_ratio=4., qkv_bias=True, qk_scale=None,
+                 drop_rate=0., attn_drop_rate=0., drop_path_rate=0., norm_layer=None,
+                 cls_attn_layers=2, use_pos=True, eta=None, tokens_norm=False, use_fpn=False,
+                 out_indices=[3, 5, 7, 11], out_dim=2048):
+        """
+        Args:
+            patch_size (int, tuple): patch size
+            embed_dim (int): embedding dimension
+            depth (int): depth of transformer
+            num_heads (int): number of attention heads
+            mlp_ratio (int): ratio of mlp hidden dim to embedding dim
+            qkv_bias (bool): enable bias for qkv if True
+            qk_scale (float): override default qk scale of head_dim ** -0.5 if set
+            drop_rate (float): dropout rate
+            attn_drop_rate (float): attention dropout rate
+            drop_path_rate (float): stochastic depth rate
+            norm_layer: (nn.Module): normalization layer
+            cls_attn_layers: (int) Depth of Class attention layers (not used for dense feature maps)
+            use_pos: (bool) whether to use positional encoding
+            eta: (float) layerscale initialization value
+            tokens_norm: (bool) Whether to normalize all tokens or just the cls_token in the CA (not used for dense feature maps)
+            use_fpn: (bool) if True, use FPN features
+            out_indices: (list) Indices of layers from which FPN features are extracted
+            out_dim: (int) Output dimension if no FPN is used
+        """
+        super().__init__()
+        self.num_features = self.embed_dim = embed_dim
+        norm_layer = norm_layer or partial(nn.LayerNorm, eps=1e-6)
+
+        self.patch_embed = ConvPatchEmbed(embed_dim=embed_dim, patch_size=patch_size)
+
+        self.pos_drop = nn.Dropout(p=drop_rate)
+
+        dpr = [drop_path_rate for i in range(depth)]
+        self.blocks = nn.ModuleList([
+            XCABlock(
+                dim=embed_dim, num_heads=num_heads, mlp_ratio=mlp_ratio, qkv_bias=qkv_bias,
+                qk_scale=qk_scale, drop=drop_rate, attn_drop=attn_drop_rate, drop_path=dpr[i],
+                norm_layer=norm_layer, eta=eta)
+            for i in range(depth)])
+
+        self.pos_embeder = PositionalEncodingFourier(dim=embed_dim)
+        self.use_pos = use_pos
+
+        self.use_fpn = use_fpn
+        self.out_indices = out_indices
+        if use_fpn:
+            self.fpn1, self.fpn2, self.fpn3, self.fpn4 = self.init_fpn(patch_size, embed_dim)
+        else:
+            self.out_projection = nn.Conv2d(embed_dim, out_dim, kernel_size=1, stride=1)
+
+    def init_fpn(self, patch_size, embed_dim):
+        """Initializes layers for FPN if used"""
+
+        if patch_size == 16:
+            fpn1 = nn.Sequential(
+                nn.ConvTranspose2d(embed_dim, embed_dim, kernel_size=2, stride=2),
+                nn.BatchNorm2d(embed_dim),
+                nn.GELU(),
+                nn.ConvTranspose2d(embed_dim, embed_dim, kernel_size=2, stride=2),
+            )
+
+            fpn2 = nn.Sequential(
+                nn.ConvTranspose2d(embed_dim, embed_dim, kernel_size=2, stride=2),
+            )
+
+            fpn3 = nn.Identity()
+
+            fpn4 = nn.MaxPool2d(kernel_size=2, stride=2)
+
+        elif patch_size == 8:
+            fpn1 = nn.Sequential(
+                nn.ConvTranspose2d(embed_dim, embed_dim, kernel_size=2, stride=2),
+            )
+
+            fpn2 = nn.Identity()
+
+            fpn3 = nn.Sequential(
+                nn.MaxPool2d(kernel_size=2, stride=2),
+            )
+
+            fpn4 = nn.Sequential(
+                nn.MaxPool2d(kernel_size=4, stride=4),
+            )
+
+        else:
+            raise ValueError("Invalid patch size for FPN")
+
+        return fpn1, fpn2, fpn3, fpn4
+
+    @torch.jit.ignore
+    def no_weight_decay(self):
+        return {'pos_embed', 'cls_token', 'dist_token'}
+
+    def init_weights(self, pretrained=None, strict=False):
+        """Initialize the weights in backbone.
+        Args:
+            pretrained (str, optional): Path to pre-trained weights.
+                Defaults to None.
+            strict (bool): whether to strictly enforce that the keys in state_dict
+                match the keys returned by this module’s state_dict() function.
+                Defaults to False.
+        """
+        def _init_weights(m):
+            if isinstance(m, nn.Linear):
+                trunc_normal_(m.weight, std=.02)
+                if isinstance(m, nn.Linear) and m.bias is not None:
+                    nn.init.constant_(m.bias, 0)
+            elif isinstance(m, nn.LayerNorm):
+                nn.init.constant_(m.bias, 0)
+                nn.init.constant_(m.weight, 1.0)
+
+        if isinstance(pretrained, str):
+            self.apply(_init_weights)
+
+            if pretrained.startswith('https'):
+                checkpoint = torch.hub.load_state_dict_from_url(pretrained, map_location='cpu')
+            else:
+                checkpoint = torch.load(pretrained, map_location='cpu')
+
+            checkpoint_model = checkpoint['model']
+            missing_keys = self.load_state_dict(checkpoint_model, strict=strict)
+            # Uncomment to print missing_keys
+            # print(missing_keys)
+
+        elif pretrained is None:
+            self.apply(_init_weights)
+        else:
+            raise TypeError('pretrained must be a str or None')
+
+    def extract_fpn(self, x, B, Hp, Wp):
+        features = []
+        for i, blk in enumerate(self.blocks):
+            x = blk(x, Hp, Wp)
+            if i in self.out_indices:
+                xp = x.permute(0, 2, 1).reshape(B, -1, Hp, Wp)
+                features.append(xp)
+
+        ops = [self.fpn1, self.fpn2, self.fpn3, self.fpn4]
+        for i in range(len(features)):
+            features[i] = ops[i](features[i])
+
+        return tuple(features)
+
+    def forward_features(self, x):
+        B, C, H, W = x.shape
+        x, (Hp, Wp) = self.patch_embed(x)
+
+        pos_encoding = self.pos_embeder(B, Hp, Wp).reshape(B, -1, x.shape[1]).permute(0, 2, 1)
+
+        if self.use_pos:
+            x = x + pos_encoding
+
+        x = self.pos_drop(x)
+
+        if self.use_fpn:
+            return self.extract_fpn(x, B, Hp, Wp)
+        else:
+            for i, blk in enumerate(self.blocks):
+                x = blk(x, Hp, Wp)
+
+            # Permute and project to obtain feature map
+            xp = x.permute(0, 2, 1).reshape(B, -1, Hp, Wp)
+            xp = self.out_projection(xp)
+            return xp
+
+    def forward(self, x):
+        x = self.forward_features(x)
+        return x
+
+
+# Architectures
+# Patch size 16x16 models
+def xcit_nano_12_p16(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=16, embed_dim=128, depth=12, num_heads=4, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1.0, tokens_norm=False, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_nano_12_p16_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_tiny_12_p16(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=16, embed_dim=192, depth=12, num_heads=4, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1.0, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_tiny_12_p16_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_small_12_p16(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=16, embed_dim=384, depth=12, num_heads=8, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1.0, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_small_12_p16_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_tiny_24_p16(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=16, embed_dim=192, depth=24, num_heads=4, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_tiny_24_p16_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_small_24_p16(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=16, embed_dim=384, depth=24, num_heads=8, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_small_24_p16_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_medium_24_p16(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=16, embed_dim=512, depth=24, num_heads=8, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_medium_24_p16_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_large_24_p16(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=16, embed_dim=768, depth=24, num_heads=16, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_large_24_p16_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model

--- a/openpifpaf/network/xcit.py
+++ b/openpifpaf/network/xcit.py
@@ -347,7 +347,19 @@ class XCiT(nn.Module):
         if use_fpn:
             self.fpn1, self.fpn2, self.fpn3, self.fpn4 = self.init_fpn(patch_size, embed_dim)
         else:
-            self.out_projection = nn.Conv2d(embed_dim, out_dim, kernel_size=1, stride=1)
+            # Out Projection layer added, not present in original implementation
+            if patch_size == 16:
+                self.out_projection = nn.Sequential(
+                    nn.Conv2d(embed_dim, out_dim, kernel_size=1, stride=1),
+                )
+
+            elif patch_size == 8:
+                self.out_projection = nn.Sequential(
+                    nn.Conv2d(embed_dim, out_dim, kernel_size=1, stride=1),
+                    nn.MaxPool2d(kernel_size=2, stride=2),
+                )
+            else:
+                raise ValueError("Invalid patch size for network")
 
     def init_fpn(self, patch_size, embed_dim):
         """Initializes layers for FPN if used"""
@@ -530,5 +542,68 @@ def xcit_large_24_p16(pretrained=True, **kwargs):
         patch_size=16, embed_dim=768, depth=24, num_heads=16, mlp_ratio=4, qkv_bias=True,
         norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
     url = "https://dl.fbaipublicfiles.com/xcit/xcit_large_24_p16_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+# Patch size 8x8 models
+def xcit_nano_12_p8(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=8, embed_dim=128, depth=12, num_heads=4, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1.0, tokens_norm=False, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_nano_12_p8_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_tiny_12_p8(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=8, embed_dim=192, depth=12, num_heads=4, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1.0, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_tiny_12_p8_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_small_12_p8(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=8, embed_dim=384, depth=12, num_heads=8, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1.0, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_small_12_p8_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_tiny_24_p8(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=8, embed_dim=192, depth=24, num_heads=4, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_tiny_24_p8_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_small_24_p8(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=8, embed_dim=384, depth=24, num_heads=8, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_small_24_p8_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_medium_24_p8(pretrained=True, **kwargs):
+    model = XCiT(
+        patch_size=8, embed_dim=512, depth=24, num_heads=8, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_medium_24_p8_384_dist.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def xcit_large_24_p8(pretrained=None, **kwargs):
+    model = XCiT(
+        patch_size=8, embed_dim=768, depth=24, num_heads=16, mlp_ratio=4, qkv_bias=True,
+        norm_layer=partial(nn.LayerNorm, eps=1e-6), eta=1e-5, tokens_norm=True, **kwargs)
+    url = "https://dl.fbaipublicfiles.com/xcit/xcit_large_24_p8_384_dist.pth"
     model.init_weights(url if pretrained else None)
     return model

--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,12 @@ setup(
         'torchvision>=0.8.2',
         'pillow!=8.3.0',  # exclusion torchvision 0.10.0 compatibility
         'dataclasses; python_version<"3.7"',
-        'timm>=0.4.9',  # For Swin and XCiT
     ],
     extras_require={
+        'backbones': [
+            'timm>=0.4.9',  # For Swin Transformer and XCiT
+
+        ]
         'dev': [
             'cython',
             'flameprof',

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,6 @@ setup(
     extras_require={
         'backbones': [
             'timm>=0.4.9',  # For Swin Transformer and XCiT
-
         ],
         'dev': [
             'cython',

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
         'torchvision>=0.8.2',
         'pillow!=8.3.0',  # exclusion torchvision 0.10.0 compatibility
         'dataclasses; python_version<"3.7"',
+        'timm>=0.4.9',  # For Swin and XCiT
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         'backbones': [
             'timm>=0.4.9',  # For Swin Transformer and XCiT
 
-        ]
+        ],
         'dev': [
             'cython',
             'flameprof',


### PR DESCRIPTION
New backbones:
- Swin Transformer family (https://arxiv.org/abs/2103.14030)
- XCiT family (https://arxiv.org/abs/2106.09681): includes both patch size 8 and patch size 16 architectures, with configurable output stride through CLI

Both of these architectures depend on [timm](https://github.com/rwightman/pytorch-image-models). A new "backbones" extra requirement has been added for that purpose.