### PR TITLE
Swin Transformer: Swin-B window 12, Swin-L and DDP compatibility

### DIFF
--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -578,7 +578,7 @@ class SwinTransformer(BaseNetwork):
             self.input_upsample_op = torch.nn.Upsample(scale_factor=2)
 
         if not self.use_fpn:
-            out_indices = [3,]
+            out_indices = [3, ]
         else:
             out_indices = list(range(self.fpn_level - 1, 4))
 

--- a/openpifpaf/network/basenetworks.py
+++ b/openpifpaf/network/basenetworks.py
@@ -577,8 +577,14 @@ class SwinTransformer(BaseNetwork):
         if self.input_upsample:
             self.input_upsample_op = torch.nn.Upsample(scale_factor=2)
 
+        if not self.use_fpn:
+            out_indices = [3,]
+        else:
+            out_indices = list(range(self.fpn_level - 1, 4))
+
         self.backbone = swin_net(pretrained=self.pretrained,
-                                 drop_path_rate=self.drop_path_rate)
+                                 drop_path_rate=self.drop_path_rate,
+                                 out_indices=out_indices)
 
         self.fpn = None
         if self.use_fpn:

--- a/openpifpaf/network/factory.py
+++ b/openpifpaf/network/factory.py
@@ -74,6 +74,12 @@ BASE_FACTORIES = {
         'swin_s', swin_transformer.swin_small_patch4_window7),
     'swin_b': lambda: basenetworks.SwinTransformer(
         'swin_b', swin_transformer.swin_base_patch4_window7),
+    'swin_b_window_12': lambda: basenetworks.SwinTransformer(
+        'swin_b_window_12', swin_transformer.swin_base_patch4_window12),
+    'swin_l': lambda: basenetworks.SwinTransformer(
+        'swin_l', swin_transformer.swin_large_patch4_window7),
+    'swin_l_window_12': lambda: basenetworks.SwinTransformer(
+        'swin_l_window_12', swin_transformer.swin_large_patch4_window12),
     # XCiT architectures: xcit_small_12_p16 is roughly equivalent to unmodified resnet50
     'xcit_nano_12_p16': lambda: basenetworks.XCiT('xcit_nano_12_p16', xcit.xcit_nano_12_p16),
     'xcit_tiny_12_p16': lambda: basenetworks.XCiT('xcit_tiny_12_p16', xcit.xcit_tiny_12_p16),

--- a/openpifpaf/network/swin_transformer.py
+++ b/openpifpaf/network/swin_transformer.py
@@ -655,7 +655,37 @@ def swin_base_patch4_window7(pretrained=True, **kwargs):
     model = SwinTransformer(embed_dim=128, depths=(2, 2, 18, 2), num_heads=(4, 8, 16, 32),
                             window_size=7, ape=False, patch_norm=True,
                             use_checkpoint=False, **kwargs)
-    # Note: For Swin-B, 384x384x ImageNet-1K pretraining and ImageNet-22K pretraining is also available
+    # Note: For Swin-B, ImageNet-22K pretraining is also available
     url = "https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_base_patch4_window7_224.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def swin_base_patch4_window12(pretrained=True, **kwargs):
+    model = SwinTransformer(embed_dim=128, depths=(2, 2, 18, 2), num_heads=(4, 8, 16, 32),
+                            window_size=12, ape=False, patch_norm=True,
+                            use_checkpoint=False, **kwargs)
+    # Note: Using ImageNet-22k pretraining
+    url = "https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_base_patch4_window12_384_22k.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def swin_large_patch4_window7(pretrained=True, **kwargs):
+    model = SwinTransformer(embed_dim=192, depths=(2, 2, 18, 2), num_heads=(6, 12, 24, 48),
+                            window_size=7, ape=False, patch_norm=True,
+                            use_checkpoint=False, **kwargs)
+    # Note: Using ImageNet-22k pretraining
+    url = "https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_large_patch4_window7_224_22k.pth"
+    model.init_weights(url if pretrained else None)
+    return model
+
+
+def swin_large_patch4_window12(pretrained=True, **kwargs):
+    model = SwinTransformer(embed_dim=192, depths=(2, 2, 18, 2), num_heads=(6, 12, 24, 48),
+                            window_size=12, ape=False, patch_norm=True,
+                            use_checkpoint=False, **kwargs)
+    # Note: Using ImageNet-22k pretraining
+    url = "https://github.com/SwinTransformer/storage/releases/download/v1.0.0/swin_large_patch4_window12_384_22k.pth"
     model.init_weights(url if pretrained else None)
     return model


### PR DESCRIPTION
- Adds the largest Swin architectures: Swin-B window 12,  Swin-L window 7 and Swin-L window 12, all pretrained on ImageNet-22k
- Makes Swin Transformers compatible with DDP training by removing parameters not used in producing loss