### PR TITLE
Posetrack minor cleanup, protobuf compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setuptools.setup(
             'wheel',
         ],
         'onnx': [
-            'onnx',
+            'onnx<1.11',  # temporarily until tests pass again
             'onnxruntime',
             'onnx-simplifier>=0.2.9; python_version<"3.9"',  # Python 3.9 not supported yet
         ],

--- a/setup.py
+++ b/setup.py
@@ -105,9 +105,10 @@ setuptools.setup(
             'wheel',
         ],
         'onnx': [
-            'onnx<1.11',  # temporarily until tests pass again
+            'onnx',
             'onnxruntime',
             'onnx-simplifier>=0.2.9; python_version<"3.9"',  # Python 3.9 not supported yet
+            'protobuf<4',  # temporary explicit dependency until tests pass again
         ],
         'coreml': [
             'coremltools>=5.0b3',

--- a/src/openpifpaf/decoder/pose_similarity.py
+++ b/src/openpifpaf/decoder/pose_similarity.py
@@ -98,6 +98,8 @@ class PoseSimilarity(TrackBase):
                 cost[track_i + len(self.active), pose_i] = 100.0
         LOG.debug('cost time = %.3fs', time.perf_counter() - cost_start)
 
+        if scipy is None:
+            raise Exception('scipy not found. Run "pip3 install scipy" to install.')
         track_indices, pose_indices = scipy.optimize.linear_sum_assignment(cost)
         matched_poses = set()
         for track_i, pose_i in zip(track_indices, pose_indices):

--- a/src/openpifpaf/plugins/posetrack/__init__.py
+++ b/src/openpifpaf/plugins/posetrack/__init__.py
@@ -6,9 +6,7 @@ from .posetrack2017 import Posetrack2017
 
 
 def register():
-    openpifpaf.CHECKPOINT_URLS['tshufflenetv2k16'] = (
-        'http://github.com/vita-epfl/openpifpaf-torchhub/releases/download/'
-        'v0.12.2/tshufflenetv2k16-210228-220045-posetrack2018-cocokpst-o10-856584da.pkl')
+    openpifpaf.CHECKPOINT_URLS['tshufflenetv2k16'] = openpifpaf.PRETRAINED_UNAVAILABLE
     openpifpaf.CHECKPOINT_URLS['tshufflenetv2k30'] = (
         'http://github.com/openpifpaf/torchhub/releases/download/v0.12.10/'
         'tshufflenetv2k30-210628-075118-posetrack2018-cocokpst-slurm668247-o25-3d734bb8.pkl')


### PR DESCRIPTION
Tracking with pose similarity does not require a specialized tracking model and works with any of the single image models. The tracks are generated by connecting poses according to their distance in pixel space. This was one of the baselines in the paper.

`MPLBACKEND=macosx python3 -m openpifpaf.video --show --long-edge=321 --checkpoint=shufflenetv2k16 --decoder=posesimilarity:0 --source 0 --horizontal-flip`