### PR TITLE
filtering of GT bounding boxes in toannotations.py

### DIFF
--- a/src/openpifpaf/transforms/toannotations.py
+++ b/src/openpifpaf/transforms/toannotations.py
@@ -41,7 +41,7 @@ class ToKpAnnotations:
                 fixed_bbox=ann.get('bbox'),
             )
             for ann in anns
-            if not ann['iscrowd'] and np.any(ann['keypoints'][2::3] > 0.0)
+            if not ann['iscrowd'] and np.any(ann['keypoints'][:, 2] > 0.0)
         ]
 
 


### PR DESCRIPTION
**minor fix in ```transforms/toannotations.py```**

**Before:**
```ann['keypoints']``` is a 2-D array instead of a 1-D array, the current check  condition ```np.any(ann['keypoints'][2::3] > 0.0)``` incorrectly filters the **GT** bounding boxes while creating annotation object.

**After**:
Check for at least one visible keypoint with the condition ```np.any(ann['keypoints'][:, 2] > 0.0)```


