### PR TITLE
Adds build_checkpoint to network.Trainer

### DIFF
--- a/src/openpifpaf/network/trainer.py
+++ b/src/openpifpaf/network/trainer.py
@@ -407,11 +407,7 @@ class Trainer():
 
         filename = '{}.epoch{:03d}'.format(self.out, epoch)
         LOG.debug('about to write model')
-        torch.save({
-            'model': model_to_save,
-            'epoch': epoch,
-            'meta': self.model_meta_data,
-        }, filename)
+        torch.save(self.build_checkpoint(model_to_save, epoch), filename)
         LOG.info('model written: %s', filename)
 
         if final:
@@ -423,3 +419,12 @@ class Trainer():
             outname, _, outext = self.out.rpartition('.')
             final_filename = '{}-{}.{}'.format(outname, file_hash[:8], outext)
             shutil.copyfile(filename, final_filename)
+
+    def build_checkpoint(self, model, epoch):
+        return {
+            "model": model,
+            "epoch": epoch,
+            "meta": self.model_meta_data,
+        }
+
+         


### PR DESCRIPTION
This enables easily customizing the data that is saved in the checkpoints by subclassing from `network.Trainer` and overwriting build_checkpoint.