### PR TITLE
Fix --cocokp-val-annotations and --cocokp-val-image-dir being ignored when using openpifpaf.eval

### DIFF
--- a/src/openpifpaf/plugins/coco/cocokp.py
+++ b/src/openpifpaf/plugins/coco/cocokp.py
@@ -158,8 +158,10 @@ class CocoKp(openpifpaf.datasets.DataModule, openpifpaf.Configurable):
         # cocokp specific
         cls.train_annotations = args.cocokp_train_annotations
         cls.val_annotations = args.cocokp_val_annotations
+        cls.eval_annotations = cls.val_annotations
         cls.train_image_dir = args.cocokp_train_image_dir
         cls.val_image_dir = args.cocokp_val_image_dir
+        cls.eval_image_dir = cls.val_image_dir
 
         cls.square_edge = args.cocokp_square_edge
         cls.with_dense = args.cocokp_with_dense


### PR DESCRIPTION
Fix https://github.com/openpifpaf/openpifpaf/issues/597